### PR TITLE
Optimizations, linting, handling lief exceptions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
-[tool.flake8]
+[flake8]
 ignore = E203, E266, E501, W503, W605
-max-line-length = 80
+exclude = blint/cyclonedx/spec.py
+max-line-length = 99
 max-complexity = 18
 select = "B,C,E,F,W,T4,B9"

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
-[flake8]
+[tool.flake8]
 ignore = E203, E266, E501, W503, W605
-max-line-length = 79
+max-line-length = 80
 max-complexity = 18
-select = B,C,E,F,W,T4,B9
+select = "B,C,E,F,W,T4,B9"

--- a/blint/analysis.py
+++ b/blint/analysis.py
@@ -1,4 +1,5 @@
-import importlib
+import contextlib
+import importlib  # noqa
 import json
 import os
 import re
@@ -17,16 +18,15 @@ from rich.terminal_theme import MONOKAI
 
 from blint.binary import parse
 from blint.logger import LOG, console
-from blint.utils import (
-    find_exe_files,
-    is_exe,
-    is_fuzzable_name,
-    is_ignored_file,
-    parse_pe_manifest,
-)
+from blint.utils import (is_fuzzable_name, print_findings_table, )
+from blint.checks import (check_nx, check_pie, # pylint: disable=unused-import
+                          check_relro, check_canary, check_rpath,
+                          check_virtual_size, check_authenticode,
+                          check_dll_characteristics, check_codesign,
+                          check_trust_info)
 
 try:
-    import importlib.resources
+    import importlib.resources  # pylint: disable=ungrouped-imports
 
     HAVE_RESOURCE_READER = True
 except ImportError:
@@ -34,7 +34,7 @@ except ImportError:
 
 review_files = []
 if HAVE_RESOURCE_READER:
-    try:
+    with contextlib.suppress(Exception):
         review_files = (
             resource.name
             for resource in importlib.resources.files(
@@ -42,9 +42,7 @@ if HAVE_RESOURCE_READER:
             ).iterdir()
             if resource.is_file() and resource.name.endswith(".yml")
         )
-    except Exception:
-        pass
-else:
+if not review_files:
     review_methods_dir = Path(__file__).parent / "data" / "annotations"
     review_files = [
         p.as_posix() for p in Path(review_methods_dir).rglob("*.yml")
@@ -98,10 +96,10 @@ def get_resource(package, resource):
         # you may have a security vulnerability!
         resource_path = os.path.join(package_path, resource)
 
-        return open(resource_path)
+        return open(resource_path, encoding="utf-8")
 
     # Could not resolve package path from __file__.
-    LOG.warn("Unable to load resource: %s:%s" % (package, resource))
+    LOG.warning(f"Unable to load resource: {package}:{resource}")
     return None
 
 
@@ -133,250 +131,104 @@ for review_methods_file in review_files:
             for rule in all_rules:
                 method_rules_dict[rule.get("id")] = rule
                 review_rules_cache[rule.get("id")] = rule
-            for exe_type in exe_type_list:
+            for etype in exe_type_list:
                 if methods_reviews_groups.get("group") == "METHOD_REVIEWS":
-                    review_methods_dict[exe_type].append(method_rules_dict)
+                    review_methods_dict[etype].append(method_rules_dict)
                 elif methods_reviews_groups.get("group") == "EXE_REVIEWS":
-                    review_exe_dict[exe_type].append(method_rules_dict)
+                    review_exe_dict[etype].append(method_rules_dict)
                 elif methods_reviews_groups.get("group") == "SYMBOL_REVIEWS":
-                    review_symbols_dict[exe_type].append(method_rules_dict)
+                    review_symbols_dict[etype].append(method_rules_dict)
                 elif methods_reviews_groups.get("group") == "IMPORT_REVIEWS":
-                    review_imports_dict[exe_type].append(method_rules_dict)
+                    review_imports_dict[etype].append(method_rules_dict)
                 elif methods_reviews_groups.get("group") == "ENTRIES_REVIEWS":
-                    review_entries_dict[exe_type].append(method_rules_dict)
-
-
-def check_nx(f, metadata, rule_obj):
-    if metadata.get("has_nx") is False:
-        return False
-    return True
-
-
-def check_pie(f, metadata, rule_obj):
-    if metadata.get("is_pie") is False:
-        return False
-    return True
-
-
-def check_relro(f, metadata, rule_obj):
-    if metadata.get("relro") == "no":
-        return False
-    return True
-
-
-def check_canary(f, metadata, rule_obj):
-    if metadata.get("has_canary") is False:
-        return False
-    return True
-
-
-def check_rpath(f, metadata, rule_obj):
-    # Do not recommend setting rpath or runpath
-    if metadata.get("has_rpath") or metadata.get("has_runpath"):
-        return False
-    return True
-
-
-def check_virtual_size(f, metadata, rule_obj):
-    if metadata.get("virtual_size"):
-        virtual_size = metadata.get("virtual_size") / 1024 / 1024
-        size_limit = 30
-        if rule_obj.get("limit"):
-            limit = rule_obj.get("limit")
-            limit = limit.replace("MB", "").replace("M", "")
-            if isinstance(limit, str) and rule_obj.get("limit").isdigit():
-                size_limit = int(rule_obj.get("limit"))
-        return virtual_size < size_limit
-    return True
-
-
-def check_authenticode(f, metadata, rule_obj):
-    if metadata.get("authenticode"):
-        authenticode_obj = metadata.get("authenticode")
-        vf = authenticode_obj.get("verification_flags", "").lower()
-        if vf != "ok":
-            return False
-        if not authenticode_obj.get("cert_signer"):
-            return False
-        return True
-    return True
-
-
-def check_dll_characteristics(f, metadata, rule_obj):
-    if metadata.get("dll_characteristics"):
-        for c in rule_obj.get("mandatory_values", []):
-            if c not in metadata.get("dll_characteristics"):
-                return c
-    return True
-
-
-def check_codesign(f, metadata, rule_obj):
-    if metadata.get("code_signature"):
-        code_signature = metadata.get("code_signature")
-        if code_signature and code_signature.get("available") is False:
-            return False
-        return True
-    return True
-
-
-def check_trust_info(f, metadata, rule_obj):
-    if metadata.get("resources"):
-        manifest = metadata.get("resources").get("manifest")
-        if manifest:
-            attribs_dict = parse_pe_manifest(manifest)
-            if not attribs_dict:
-                return True
-            allowed_values = rule_obj.get("allowed_values", {})
-            for k, v in allowed_values.items():
-                manifest_k = attribs_dict.get(k)
-                if isinstance(v, dict) and isinstance(manifest_k, dict):
-                    for vk, vv in v.items():
-                        if str(manifest_k.get(vk)).lower() != str(vv).lower():
-                            return "{}:{}".format(vk, manifest_k.get(vk))
-    return True
+                    review_entries_dict[etype].append(method_rules_dict)
 
 
 def run_checks(f, metadata):
+    """Runs the checks on the provided metadata using the loaded rules.
+
+    Args:
+        f: The metadata of the functions.
+        metadata: The metadata containing information about the executable.
+
+    Returns:
+        A list of result dictionaries representing the outcomes of the checks.
+
+    """
     results = []
     if not rules_dict:
-        LOG.warn("No rules loaded!")
-        return None
+        LOG.warning("No rules loaded!")
+        return results
     if not metadata:
-        return None
+        return results
     exe_type = metadata.get("exe_type")
     for cid, rule_obj in rules_dict.items():
         rule_exe_types = rule_obj.get("exe_types")
         # Skip rules that are not valid for this exe type
         if exe_type and rule_exe_types and exe_type not in rule_exe_types:
             continue
-        cfn = getattr(sys.modules[__name__], cid.lower(), None)
-        if cfn:
-            result = cfn(f, metadata, rule_obj=rule_obj)
-            if result is False or isinstance(result, str):
-                aresult = {**rule_obj, "filename": f}
-                if isinstance(result, str):
-                    aresult["title"] = "{} ({})".format(
-                        aresult["title"], result
-                    )
-                if metadata.get("name"):
-                    aresult["exe_name"] = metadata.get("name")
-                aresult["exe_type"] = exe_type
-                results.append(aresult)
+        if result := run_rule(f, metadata, rule_obj, exe_type, cid):
+            results.append(result)
     return results
 
 
-def run_review_methods_symbols(review_methods_list, functions_list):
-    results = defaultdict(list)
-    found_cid = defaultdict(int)
-    found_pattern = defaultdict(int)
-    found_function = {}
-    for review_methods in review_methods_list:
-        for cid, rule_obj in review_methods.items():
-            if found_cid[cid] > EVIDENCE_LIMIT:
-                continue
-            patterns = rule_obj.get("patterns")
-            for apattern in patterns:
-                if (
-                    found_pattern[apattern] > EVIDENCE_LIMIT
-                    or found_cid[cid] > EVIDENCE_LIMIT
-                ):
-                    continue
-                for afun in functions_list:
-                    if (
-                        apattern.lower() in afun.lower()
-                    ) and not found_function.get(afun.lower()):
-                        result = {
-                            "pattern": apattern,
-                            "function": afun,
-                        }
-                        results[cid].append(result)
-                        found_cid[cid] += 1
-                        found_pattern[apattern] += 1
-                        found_function[afun.lower()] = True
-    return results
+def run_rule(f, metadata, rule_obj, exe_type, cid):
+    """
+    Runs a rule on a file with the provided metadata, rule object, executable
+    type, and component ID.
+
+    Args:
+        f (str): The file path to run the rule on.
+        metadata (dict): The metadata of the file.
+        rule_obj (dict): The rule object to compare against.
+        exe_type (str): The executable type of the file.
+        cid (str): The component ID.
+
+    Returns:
+        str or dict: The result of running the rule on the file
+    """
+    if cfn := getattr(sys.modules[__name__], cid.lower(), None):
+        result = cfn(f, metadata, rule_obj=rule_obj)
+        if result is False or isinstance(result, str):
+            aresult = {**rule_obj, "filename": f}
+            return process_result(metadata, aresult, exe_type, result)
+    return ""
 
 
-def run_review(f, metadata):
-    results = {}
-    if not review_methods_dict:
-        LOG.warn("No review methods loaded!")
-        return None
-    exe_type = metadata.get("exe_type")
-    if not metadata or not exe_type:
-        return None
-    review_methods_list = review_methods_dict.get(exe_type)
-    review_exe_list = review_exe_dict.get(exe_type)
-    review_symbols_list = review_symbols_dict.get(exe_type)
-    review_imports_list = review_imports_dict.get(exe_type)
-    review_entries_list = review_entries_dict.get(exe_type)
-    # Check if reviews are available for this exe type
-    if (
-        not review_methods_list
-        and not review_exe_list
-        and not review_symbols_list
-        and not review_imports_list
-        and not review_entries_list
-    ):
-        return None
-    if review_methods_list or review_exe_list:
-        functions_list = [
-            re.sub(r"[*&()]", "", f.get("name", ""))
-            for f in metadata.get("functions", [])
-        ]
-        if metadata.get("magic", "").startswith("PE"):
-            functions_list += [
-                f.get("name", "") for f in metadata.get("static_symbols", [])
-            ]
-        # If there are no function but static symbols use that instead
-        if not functions_list and metadata.get("static_symbols"):
-            functions_list = [
-                f.get("name", "") for f in metadata.get("static_symbols", [])
-            ]
-        LOG.debug(f"Reviewing {len(functions_list)} functions")
-        if review_methods_list:
-            results.update(
-                run_review_methods_symbols(review_methods_list, functions_list)
-            )
-        if review_exe_list:
-            results.update(
-                run_review_methods_symbols(review_exe_list, functions_list)
-            )
-    if review_symbols_list or review_exe_list:
-        symbols_list = [
-            f.get("name", "") for f in metadata.get("dynamic_symbols", [])
-        ]
-        symbols_list += [
-            f.get("name", "") for f in metadata.get("static_symbols", [])
-        ]
-        LOG.debug(f"Reviewing {len(symbols_list)} symbols")
-        if review_symbols_list:
-            results.update(
-                run_review_methods_symbols(review_symbols_list, symbols_list)
-            )
-        if review_exe_list:
-            results.update(
-                run_review_methods_symbols(review_exe_list, symbols_list)
-            )
-    if review_imports_list:
-        imports_list = [f.get("name", "") for f in metadata.get("imports", [])]
-        LOG.debug(f"Reviewing {len(imports_list)} imports")
-        results.update(
-            run_review_methods_symbols(review_imports_list, imports_list)
-        )
-    if review_entries_list:
-        entries_list = [
-            f.get("name", "")
-            for f in metadata.get("dynamic_entries", [])
-            if f.get("tag") == "NEEDED"
-        ]
-        LOG.debug(f"Reviewing {len(entries_list)} dynamic entries")
-        results.update(
-            run_review_methods_symbols(review_entries_list, entries_list)
-        )
-    return results
+def process_result(metadata, aresult, exe_type, result):
+    """Processes the result by modifying the provided result dictionary.
+
+    Args:
+        metadata: The metadata containing information about the executable.
+        aresult: The result dictionary to be modified.
+        exe_type: The type of the executable.
+        result: The result value to be processed.
+
+    Returns:
+        The modified result dictionary.
+
+    """
+    if isinstance(result, str):
+        aresult["title"] = f"{aresult['title']} ({result})"
+    if metadata.get("name"):
+        aresult["exe_name"] = metadata.get("name")
+    aresult["exe_type"] = exe_type
+    return aresult
 
 
-def run_prefuzz(f, metadata):
+def run_prefuzz(metadata):
+    """Runs the pre-fuzzing process on the given metadata.
+
+    Generates a list of fuzzable methods from the provided metadata by
+    extracting the function names and addresses.
+
+    Args:
+        metadata: The metadata containing the functions.
+
+    Returns:
+        A list of fuzzable methods with their names and addresses.
+
+    """
     functions_list = [
         {
             "name": re.sub(r"[*&()]", "", f.get("name", "")),
@@ -418,115 +270,14 @@ def run_prefuzz(f, metadata):
     return fuzzables
 
 
-def start(args, src, reports_dir):
-    files = []
-    findings = []
-    reviews = []
-    fuzzables = []
-    for s in src:
-        if os.path.isdir(s):
-            files += find_exe_files(s)
-        else:
-            if is_ignored_file(s):
-                continue
-            fullPath = os.path.abspath(s)
-            if is_exe(fullPath):
-                files.append(fullPath)
-    with Progress(
-        transient=True,
-        redirect_stderr=True,
-        redirect_stdout=True,
-        refresh_per_second=1,
-    ) as progress:
-        task = progress.add_task(
-            f"[green] Blinting {len(files)} binaries",
-            total=len(files),
-            start=True,
-        )
-        for f in files:
-            progress.update(task, description=f"Processing [bold]{f}[/bold]")
-            metadata = parse(f)
-            exe_name = metadata.get("name", "")
-            # Store raw metadata
-            metadata_file = Path(reports_dir) / (
-                os.path.basename(exe_name) + "-metadata.json"
-            )
-            LOG.debug(f"Metadata written to {metadata_file}")
-            with open(metadata_file, mode="w") as ffp:
-                json.dump(metadata, ffp, indent=True)
-            progress.update(
-                task, description=f"Checking [bold]{f}[/bold] against rules"
-            )
-            # Check security properties
-            finding = run_checks(f, metadata)
-            if finding:
-                findings += finding
-            # Perform symbol reviews
-            if not args.no_reviews:
-                progress.update(
-                    task, description="Checking methods against review rules"
-                )
-                review = run_review(f, metadata)
-                if review:
-                    for cid, evidence in review.items():
-                        aresult = {
-                            **review_rules_cache.get(cid),
-                            "evidence": evidence,
-                            "filename": f,
-                            "exe_name": exe_name,
-                        }
-                        del aresult["patterns"]
-                        reviews.append(aresult)
-            # Suggest fuzzable targets
-            if args.suggest_fuzzable:
-                fuzzdata = run_prefuzz(f, metadata)
-                if fuzzdata:
-                    fuzzables.append(
-                        {
-                            "filename": f,
-                            "exe_name": exe_name,
-                            "methods": fuzzdata,
-                        }
-                    )
-            progress.advance(task)
-    return findings, reviews, files, fuzzables
-
-
-def print_findings_table(findings, files):
-    table = Table(
-        title="BLint Findings",
-        box=box.DOUBLE_EDGE,
-        header_style="bold magenta",
-        show_lines=True,
-    )
-    table.add_column("ID")
-    if len(files) > 1:
-        table.add_column("Binary")
-    table.add_column("Title")
-    table.add_column("Severity")
-    for f in findings:
-        severity = f.get("severity").upper()
-        severity_fmt = "{}{}".format(
-            "[bright_red]" if severity in ("CRITICAL", "HIGH") else "",
-            severity,
-        )
-        if len(files) > 1:
-            table.add_row(
-                f.get("id"),
-                f.get("exe_name"),
-                f.get("title"),
-                severity_fmt,
-            )
-        else:
-            table.add_row(
-                f.get("id"),
-                f.get("title"),
-                severity_fmt,
-            )
-    console.print(table)
-
-
 def print_reviews_table(reviews, files):
+    """Prints the capability review table.
+
+    Args:
+        reviews: A list of dictionaries representing the capability reviews.
+        files: A list of file names associated with the reviews.
+
+    """
     table = Table(
         title="BLint Capability Review",
         box=box.DOUBLE_EDGE,
@@ -557,7 +308,18 @@ def print_reviews_table(reviews, files):
     console.print(table)
 
 
-def report(args, src_dir, reports_dir, findings, reviews, files, fuzzables):
+def report(src_dir, reports_dir, findings, reviews, files, fuzzables):
+    """Generates a report based on the analysis results.
+
+    Args:
+        src_dir: The source directory.
+        reports_dir: The directory to save the reports.
+        findings: A list of dictionaries representing the findings.
+        reviews: A list of dictionaries representing the reviews.
+        files: A list of file names associated with the findings and reviews.
+        fuzzables: A list of fuzzable methods.
+
+    """
     run_uuid = os.environ.get("SCAN_ID", str(uuid.uuid4()))
     common_metadata = {
         "scan_id": run_uuid,
@@ -567,7 +329,7 @@ def report(args, src_dir, reports_dir, findings, reviews, files, fuzzables):
         print_findings_table(findings, files)
         findings_file = Path(reports_dir) / "findings.json"
         LOG.info(f"Findings written to {findings_file}")
-        with open(findings_file, mode="w") as ffp:
+        with open(findings_file, mode="w", encoding="utf-8") as ffp:
             json.dump(
                 {**common_metadata, "findings": findings}, ffp, indent=True
             )
@@ -575,12 +337,12 @@ def report(args, src_dir, reports_dir, findings, reviews, files, fuzzables):
         print_reviews_table(reviews, files)
         reviews_file = Path(reports_dir) / "reviews.json"
         LOG.info(f"Review written to {reviews_file}")
-        with open(reviews_file, mode="w") as rfp:
+        with open(reviews_file, mode="w", encoding="utf-8") as rfp:
             json.dump({**common_metadata, "reviews": reviews}, rfp, indent=True)
     if fuzzables:
         fuzzables_file = Path(reports_dir) / "fuzzables.json"
         LOG.info(f"Fuzzables data written to {fuzzables_file}")
-        with open(fuzzables_file, mode="w") as rfp:
+        with open(fuzzables_file, mode="w", encoding="utf-8") as rfp:
             json.dump(
                 {**common_metadata, "fuzzables": fuzzables}, rfp, indent=True
             )
@@ -593,3 +355,294 @@ def report(args, src_dir, reports_dir, findings, reviews, files, fuzzables):
     html_file = Path(reports_dir) / "blint-output.html"
     console.save_html(html_file, theme=MONOKAI)
     LOG.info(f"HTML report written to {html_file}")
+
+
+class AnalysisRunner:
+    """Class to analyze binaries."""
+    def __init__(self):
+        self.findings = []
+        self.reviews = []
+        self.fuzzables = []
+        self.progress = Progress(
+            transient=True, redirect_stderr=True,
+            redirect_stdout=True, refresh_per_second=1, )
+        self.task = None
+        self.reviewer = None
+
+    def start(self, args, files, reports_dir):
+        """Starts the analysis process for the given source files.
+
+        This function takes the command-line arguments and the reports
+        directory as input, and starts the analysis process. It iterates over
+        the source files, parses the metadata, checks the security properties,
+        performs symbol reviews, and suggests fuzzable targets if specified.
+
+        Args:
+            files (list): The list of source files to be analyzed.
+            args: The command-line arguments.
+            reports_dir: The directory where the reports will be stored.
+
+        Returns:
+            tuple: A tuple of the findings, reviews, files, and fuzzables.
+        """
+        with self.progress:
+            self.task = self.progress.add_task(
+                f"[green] Blinting {len(files)} binaries",
+                total=len(files), start=True, )
+            for f in files:
+                self._process_files(f, args, reports_dir)
+        return self.findings, self.reviews, self.fuzzables
+
+    def _process_files(self, f, args, reports_dir):
+        """Processes the given file and generates findings.
+
+        Args:
+            f: The file to be processed.
+            args: The command-line arguments.
+            reports_dir: The directory where the reports will be stored.
+
+        """
+        self.progress.update(
+            self.task, description=f"Processing [bold]{f}[/bold]")
+        metadata = parse(f)
+        exe_name = metadata.get("name", "")
+        # Store raw metadata
+        metadata_file = (Path(reports_dir) / f"{os.path.basename(exe_name)}"
+                                             f"-metadata.json")
+        LOG.debug(f"Metadata written to {metadata_file}")
+        with open(metadata_file, mode="w", encoding="utf-8") as ffp:
+            json.dump(metadata, ffp, indent=True)
+        self.progress.update(
+            self.task,
+            description=f"Checking [bold]{f}[/bold] against rules")
+        if finding := run_checks(f, metadata):
+            self.findings += finding
+        # Perform symbol reviews
+        if not args.no_reviews:
+            self.do_review(exe_name, f, metadata)
+        # Suggest fuzzable targets
+        if args.suggest_fuzzable and (fuzzdata := run_prefuzz(metadata)):
+            self.fuzzables.append(
+                {
+                    "filename": f,
+                    "exe_name": exe_name,
+                    "methods": fuzzdata,
+                }
+            )
+        self.progress.advance(self.task)
+
+    def do_review(self, exe_name, f, metadata):
+        """Performs a review of the given file."""
+        self.progress.update(
+            self.task, description="Checking methods against review rules")
+        self.reviewer = ReviewRunner()
+        self.reviewer.run_review(metadata)
+        if self.reviewer.results:
+            review = self.reviewer.process_review(f, exe_name)
+            self.reviews.extend(review)
+
+
+class ReviewRunner:
+    """Class for running reviews."""
+
+    def __init__(self):
+        self.results = {}
+        self.review_methods_list = []
+        self.review_exe_list = []
+        self.review_symbols_list = []
+        self.review_imports_list = []
+        self.review_entries_list = []
+
+    def run_review(self, metadata):
+        """
+        Runs a review of the given file and metadata.
+
+        This function performs a review of the file and metadata based on the
+        available review methods for the executable type. It collects the
+        results from different review methods, including methods for functions,
+        symbols, imports, and dynamic entries.
+
+        Returns:
+            dict[str, list]: Review results where the keys are the review
+            method IDs and the values are lists of matching results.
+        """
+        if not review_methods_dict:
+            LOG.warning("No review methods loaded!")
+            return {}
+        if not metadata or not (exe_type := metadata.get("exe_type")):
+            return {}
+        self._gen_review_lists(exe_type)
+        # Check if reviews are available for this exe type
+        if (
+                self.review_methods_list or
+                self.review_exe_list or
+                self.review_symbols_list or
+                self.review_imports_list or
+                self.review_entries_list
+        ):
+            return self._review_lists(metadata)
+        return {}
+
+    def _review_lists(self, metadata):
+        """
+        Reviews lists in the metadata and performs specific actions based on the
+        review type.
+
+        Args:
+            metadata (dict): The metadata to review.
+
+        Returns:
+            dict: The results of the review.
+        """
+        if self.review_methods_list or self.review_exe_list:
+            self._methods_or_exe(metadata)
+        if self.review_symbols_list or self.review_exe_list:
+            self._review_symbols_exe(metadata)
+        if self.review_imports_list:
+            self._review_imports(metadata)
+        if self.review_entries_list:
+            self._review_entries(metadata)
+        return self.results
+
+    def _review_imports(self, metadata):
+        """
+        Reviews imports in the metadata.
+
+        Args:
+            metadata (dict): The metadata to review.
+        """
+        imports_list = [f.get("name", "") for f in metadata.get("imports", [])]
+        LOG.debug(f"Reviewing {len(imports_list)} imports")
+        self.run_review_methods_symbols(self.review_imports_list, imports_list)
+
+    def _review_entries(self, metadata):
+        """
+        Reviews entries in the metadata and performs specific actions based on
+        the review type.
+
+        Args:
+            metadata (dict): The metadata to review.
+
+        Returns:
+            dict: The results of the review.
+        """
+        entries_list = [f.get("name", "") for f in
+                        metadata.get("dynamic_entries", []) if
+                        f.get("tag") == "NEEDED"]
+        LOG.debug(f"Reviewing {len(entries_list)} dynamic entries")
+        self.run_review_methods_symbols(self.review_entries_list, entries_list)
+
+    def _review_symbols_exe(self, metadata):
+        """
+        Reviews symbols in the metadata.
+
+        Args:
+            metadata (dict): The metadata to review.
+        """
+        symbols_list = [f.get("name", "") for f in
+                        metadata.get("dynamic_symbols", [])]
+        symbols_list += [f.get("name", "") for f in
+                         metadata.get("static_symbols", [])]
+        LOG.debug(f"Reviewing {len(symbols_list)} symbols")
+        if self.review_symbols_list:
+            self.run_review_methods_symbols(
+                self.review_symbols_list, symbols_list)
+        if self.review_exe_list:
+            self.run_review_methods_symbols(self.review_exe_list, symbols_list)
+
+    def _methods_or_exe(self, metadata):
+        """
+        Reviews lists in the metadata and performs specific actions based on the
+        review type.
+
+        Args:
+            metadata (dict): The metadata to review.
+        """
+        functions_list = [re.sub(r"[*&()]", "", f.get("name", "")) for f in
+                          metadata.get("functions", [])]
+        if metadata.get("magic", "").startswith("PE"):
+            functions_list += [f.get("name", "") for f in
+                               metadata.get("static_symbols", [])]
+        # If there are no function but static symbols use that instead
+        if not functions_list and metadata.get("static_symbols"):
+            functions_list = [f.get("name", "") for f in
+                              metadata.get("static_symbols", [])]
+        LOG.debug(f"Reviewing {len(functions_list)} functions")
+        if self.review_methods_list:
+            self.run_review_methods_symbols(
+                self.review_methods_list, functions_list)
+        if self.review_exe_list:
+            self.run_review_methods_symbols(
+                self.review_exe_list, functions_list)
+
+    def _gen_review_lists(self, exe_type):
+        """
+        Generates the review lists based on the given executable type.
+
+        This function takes the executable type as input and generates the
+        review lists for the corresponding type. It retrieves the review lists
+        from the review dictionaries based on the executable type.
+        """
+        self.review_methods_list = review_methods_dict.get(exe_type)
+        self.review_exe_list = review_exe_dict.get(exe_type)
+        self.review_symbols_list = review_symbols_dict.get(exe_type)
+        self.review_imports_list = review_imports_dict.get(exe_type)
+        self.review_entries_list = review_entries_dict.get(exe_type)
+
+    def process_review(self, f, exe_name):
+        """
+        Processes the review results for the given executable and review.
+
+        Returns:
+            list[dict]: The processed review result.
+        """
+        reviews = []
+        if not self.results:
+            return {}
+        for cid, evidence in self.results.items():
+            aresult = {**review_rules_cache.get(cid), "evidence": evidence,
+                       "filename": f, "exe_name": exe_name, }
+            del aresult["patterns"]
+            reviews.append(aresult)
+        return reviews
+
+    def run_review_methods_symbols(self, review_list, functions_list):
+        """Runs a review of methods and symbols based on the provided lists.
+
+        This function takes a list of review methods and a list of functions and
+        performs a review to find matches between the patterns specified in the
+        review methods and the functions. It returns a dictionary of results
+        where the keys are the review method IDs and the values are lists of
+        matching results.
+
+        Args:
+            review_list (list[dict]): The review methods or symbols.
+            functions_list (list): A list of functions to be reviewed.
+
+        Returns:
+            dict[str, list]: Method/symbol IDs and their results.
+        """
+        results = defaultdict(list)
+        found_cid = defaultdict(int)
+        found_pattern = defaultdict(int)
+        found_function = {}
+        if not review_list:
+            return
+        for review_methods in review_list:
+            for cid, rule_obj in review_methods.items():
+                if found_cid[cid] > EVIDENCE_LIMIT:
+                    continue
+                patterns = rule_obj.get("patterns")
+                for apattern in patterns:
+                    if (found_pattern[apattern] > EVIDENCE_LIMIT or found_cid[
+                            cid] > EVIDENCE_LIMIT):
+                        continue
+                    for afun in functions_list:
+                        if ((apattern.lower() in afun.lower()) and not
+                                found_function.get(afun.lower())):
+                            result = {"pattern": apattern, "function": afun, }
+                            results[cid].append(result)
+                            found_cid[cid] += 1
+                            found_pattern[apattern] += 1
+                            found_function[afun.lower()] = True
+        self.results |= results

--- a/blint/binary.py
+++ b/blint/binary.py
@@ -1,11 +1,17 @@
+# pylint: disable=too-many-lines,consider-using-f-string
 import contextlib
 import sys
 
 import lief
 
 from blint.logger import DEBUG, LOG
-from blint.utils import calculate_entropy, check_secret, \
-    cleanup_dict_lief_errors, cleanup_list_lief_errors, decode_base64
+from blint.utils import (
+    calculate_entropy,
+    check_secret,
+    cleanup_dict_lief_errors,
+    cleanup_list_lief_errors,
+    decode_base64
+)
 
 MIN_ENTROPY = 0.39
 MIN_LENGTH = 80
@@ -51,12 +57,12 @@ def parse_notes(parsed_obj):
         list[dict]: A list of metadata dictionaries, each representing a note.
 
     Note:
-        - The description is truncated to 16 words and appended with "..." if 
+        - The description is truncated to 16 words and appended with "..." if
             it exceeds 16 words.
     """
     data = []
     notes = parsed_obj.notes
-    if not notes:
+    if isinstance(notes, lief.lief_errors):
         return data
     data.extend(extract_note_data(idx, note) for idx, note in enumerate(notes))
     return cleanup_list_lief_errors(data)
@@ -69,7 +75,6 @@ def extract_note_data(idx, note):
     Args:
         idx (int): The index of the note.
         note: The note object to extract data from.
-    
     Returns:
         dict: A dictionary containing the extracted metadata
     """
@@ -102,12 +107,20 @@ def extract_note_data(idx, note):
         version_str = build_id
     if note.is_core:
         note_details_str = note.details
-    return cleanup_dict_lief_errors({
-        "index": idx, "description": description_str, "type": type_str,
-        "details": note_details_str, "sdk_version": sdk_version,
-        "ndk_version": ndk_version, "ndk_build_number": ndk_build_number,
-        "abi": abi, "version": version_str, "build_id": build_id,
-    })
+    return cleanup_dict_lief_errors(
+        {
+            "index": idx,
+            "description": description_str,
+            "type": type_str,
+            "details": note_details_str,
+            "sdk_version": sdk_version,
+            "ndk_version": ndk_version,
+            "ndk_build_number": ndk_build_number,
+            "abi": abi,
+            "version": version_str,
+            "build_id": build_id,
+        }
+    )
 
 
 def integer_to_hex_str(e):
@@ -193,15 +206,10 @@ def parse_strings(parsed_obj):
                 if s and "[]" not in s and "{}" not in s:
                     entropy = calculate_entropy(s)
                     secret_type = check_secret(s)
-                    if (
-                        entropy and
-                        (entropy > MIN_ENTROPY or len(s) > MIN_LENGTH)
-                    ) or secret_type:
+                    if (entropy and (entropy > MIN_ENTROPY or len(s) > MIN_LENGTH)) or secret_type:
                         strings_list.append(
                             {
-                                "value": (
-                                    decode_base64(s) if s.endswith("==") else s
-                                ),
+                                "value": (decode_base64(s) if s.endswith("==") else s),
                                 "entropy": entropy,
                                 "secret_type": secret_type,
                             }
@@ -229,11 +237,9 @@ def parse_symbols(symbols):
             symbol_version = symbol.symbol_version if symbol.has_version else ""
             is_imported = False
             is_exported = False
-            if symbol.imported and not isinstance(
-                    symbol.imported, lief.lief_errors):
+            if symbol.imported and not isinstance(symbol.imported, lief.lief_errors):
                 is_imported = True
-            if symbol.exported and not isinstance(
-                    symbol.exported, lief.lief_errors):
+            if symbol.exported and not isinstance(symbol.exported, lief.lief_errors):
                 is_exported = True
             symbol_name = symbol.demangled_name
             if isinstance(symbol_name, lief.lief_errors):
@@ -262,44 +268,25 @@ def parse_symbols(symbols):
     return cleanup_list_lief_errors(symbols_list), exe_type
 
 
-def parse_interpreter(parsed_obj):
-    """
-    Parses the interpreter information from the given parsed binary object.
-
-    Args:
-        parsed_obj: The parsed binary object to extract the interpreter from.
-
-    Returns:
-        str: The interpreter information of the binary object.
-    """
-    try:
-        interpreter =  parsed_obj.interpreter
-        if isinstance(interpreter, lief.lief_errors):
-            raise AttributeError
-        return interpreter
-    except AttributeError:
-        return ""
-
-
 def detect_exe_type(parsed_obj, metadata):
     """
-    Detects the type of the parsed binary object based on its characteristics 
+    Detects the type of the parsed binary object based on its characteristics
     and metadata.
 
     Args:
         parsed_obj: The parsed binary object to analyze.
-        metadata (dict): The metadata dictionary containing binary information .
+        metadata (dict): The metadata dictionary containing binary information.
 
     Returns:
         str: The detected type of the binary.
     """
-    try:
+    with contextlib.suppress(AttributeError, TypeError):
         if parsed_obj.has_section(".note.go.buildid"):
             return "gobinary"
         if (
-            parsed_obj.has_section(".note.gnu.build-id")
-            or "musl" in metadata.get("interpreter")
-            or "ld-linux" in metadata.get("interpreter")
+                parsed_obj.has_section(".note.gnu.build-id")
+                or "musl" in metadata.get("interpreter")
+                or "ld-linux" in metadata.get("interpreter")
         ):
             return "genericbinary"
         if metadata.get("machine_type") and metadata.get("file_type"):
@@ -307,8 +294,6 @@ def detect_exe_type(parsed_obj, metadata):
                     f'{metadata.get("file_type")}').lower()
         if metadata["relro"] in ("partial", "full"):
             return "genericbinary"
-    except (AttributeError, TypeError):
-        return ""
     return ""
 
 
@@ -343,37 +328,35 @@ def parse_pe_data(parsed_obj):
         list[dict]: A list of dictionaries, each representing a data directory.
     """
     data_list = []
-    with contextlib.suppress(AttributeError, IndexError):
-        LOG.debug("Parsing data dictionaries")
-        data_directories = parsed_obj.data_directories
-        for directory in data_directories:
-            section_name = ""
-            section_chars = ""
-            section_entropy = ""
-            dir_type = str(directory.type).rsplit(".", maxsplit=1)[-1]
-            if not dir_type.startswith("?") and directory.size:
-                if directory.has_section:
-                    if directory.section.has_characteristic:
-                        section_chars = ", ".join(
-                            [
-                                str(chara).rsplit(".", maxsplit=1)[-1]
-                                for chara
-                                in directory.section.characteristics_lists
-                            ]
-                        )
-                    section_name = directory.section.name
-                    section_entropy = directory.section.entropy
-                data_list.append(
-                    {
-                        "name": section_name,
-                        "type": dir_type,
-                        "rva": directory.rva,
-                        "size": directory.size,
-                        "section_characteristics": section_chars,
-                        "section_entropy": section_entropy,
-                    }
-                )
-    return cleanup_list_lief_errors(data_list)
+    LOG.debug("Parsing data dictionaries")
+    data_directories = parsed_obj.data_directories
+    if not data_directories or isinstance(data_directories, lief.lief_errors):
+        return data_list
+    for directory in data_directories:
+        section_name = ""
+        section_chars = ""
+        section_entropy = ""
+        dir_type = str(directory.type).rsplit(".", maxsplit=1)[-1]
+        if not dir_type.startswith("?") and directory.size:
+            if directory.has_section:
+                if directory.section.has_characteristic:
+                    section_chars = ", ".join(
+                        [str(chara).rsplit(".", maxsplit=1)[-1] for chara in
+                            directory.section.characteristics_lists]
+                    )
+                section_name = directory.section.name
+                section_entropy = directory.section.entropy
+            data_list.append(
+                {
+                    "name": section_name,
+                    "type": dir_type,
+                    "rva": directory.rva,
+                    "size": directory.size,
+                    "section_characteristics": section_chars,
+                    "section_entropy": section_entropy,
+                }
+            )
+    return data_list
 
 
 def process_pe_resources(parsed_obj):
@@ -387,34 +370,35 @@ def process_pe_resources(parsed_obj):
     Returns:
         dict: A dictionary containing metadata about the resources
     """
-    try:
-        LOG.debug("Parsing PE resources")
-        rm = parsed_obj.resources_manager
-        return cleanup_dict_lief_errors({
-            "has_accelerator": rm.has_accelerator, "has_dialogs": rm.has_dialogs,
-            "has_html": rm.has_html, "has_icons": rm.has_icons,
-            "has_manifest": rm.has_manifest,
-            "has_string_table": rm.has_string_table,
-            "has_version": rm.has_version,
-            "html": rm.html if rm.has_html else None, "manifest": (
-            rm.manifest.replace("\\xef\\xbb\\xbf",
-                                "") if rm.has_manifest else None),
-            "version_info": str(rm.version) if rm.has_version else None,
-        })
-    except AttributeError:
+    LOG.debug("Parsing PE resources")
+    rm = parsed_obj.resources_manager
+    if not rm or isinstance(rm, lief.lief_errors):
         return {}
+    return {
+        "has_accelerator": rm.has_accelerator,
+        "has_dialogs": rm.has_dialogs,
+        "has_html": rm.has_html,
+        "has_icons": rm.has_icons,
+        "has_manifest": rm.has_manifest,
+        "has_string_table": rm.has_string_table,
+        "has_version": rm.has_version,
+        "html": rm.html if rm.has_html else None,
+        "manifest": (
+            rm.manifest.replace("\\xef\\xbb\\xbf", "") if rm.has_manifest else None),
+        "version_info": str(rm.version) if rm.has_version else None,
+    }
 
 
 def process_pe_signature(parsed_obj):
     """
-    Processes the signatures of the parsed PE (Portable Executable) binary 
+    Processes the signatures of the parsed PE (Portable Executable) binary
     object and returns information about the signatures.
 
     Args:
         parsed_obj: The parsed PE binary object to process the signatures from.
-    
+
     Returns:
-        list[dict]: A list of dictionaries containing signatures info. 
+        list[dict]: A list of dictionaries containing signatures info.
     """
     signature_list = []
     with contextlib.suppress(AttributeError, TypeError, KeyError):
@@ -457,34 +441,31 @@ def parse_pe_authenticode(parsed_obj):
     """
     try:
         LOG.debug("Parsing authentihash")
-        authenticode = {}
         sep = ":" if sys.version_info.minor > 7 else ()
-        authenticode["md5_hash"] = parsed_obj.authentihash_md5.hex(*sep)
-        authenticode["sha256_hash"] = parsed_obj.authentihash_sha256.hex(*sep)
-        authenticode["sha512_hash"] = parsed_obj.authentihash_sha512.hex(*sep)
-        authenticode["sha1_hash"] = parsed_obj.authentihash(
-            lief.PE.ALGORITHMS.SHA_1
-        ).hex(*sep)
-        authenticode["verification_flags"] = str(
-            parsed_obj.verify_signature()
-        ).replace("VERIFICATION_FLAGS.", "")
-        if (
-            parsed_obj.signatures
-            and len(parsed_obj.signatures) > 0
-            and parsed_obj.signatures[0].signers
-        ):
-            cert_signer_str = str(parsed_obj.signatures[0].signers[0].cert)
-            cert_signer_obj = {}
-            for p in cert_signer_str.split("\n"):
-                tmp_a = p.split(" : ")
-                if len(tmp_a) == 2:
-                    tmp_key = tmp_a[0].strip().replace(" ", "_")
-                    if "version" in tmp_key:
-                        tmp_key = "version"
-                    cert_signer_obj[tmp_key] = tmp_a[1].strip()
-            authenticode["cert_signer"] = cert_signer_obj
-        return cleanup_dict_lief_errors(authenticode)
-    except (AttributeError, IndexError, KeyError, TypeError):
+        authenticode = {
+            "md5_hash": parsed_obj.authentihash_md5.hex(*sep),
+            "sha256_hash": parsed_obj.authentihash_sha256.hex(*sep),
+            "sha512_hash": parsed_obj.authentihash_sha512.hex(*sep),
+            "sha1_hash": parsed_obj.authentihash(lief.PE.ALGORITHMS.SHA_1).hex(*sep),
+            "verification_flags": str(parsed_obj.verify_signature()).replace(
+                "VERIFICATION_FLAGS.", ""
+            )
+        }
+        if signatures := parsed_obj.signatures:
+            if not isinstance(signatures, lief.lief_errors) and signatures[0].signers:
+                cert_signer_str = str(parsed_obj.signatures[0].signers[0].cert)
+                cert_signer_obj = {}
+                for p in cert_signer_str.split("\n"):
+                    tmp_a = p.split(" : ")
+                    if len(tmp_a) == 2:
+                        tmp_key = tmp_a[0].strip().replace(" ", "_")
+                        if "version" in tmp_key:
+                            tmp_key = "version"
+                        cert_signer_obj[tmp_key] = tmp_a[1].strip()
+                authenticode["cert_signer"] = cert_signer_obj
+        return authenticode
+    except (AttributeError, IndexError, KeyError, TypeError) as e:
+        LOG.exception(f"Caught {type(e)} while parsing PE authentihash.")
         return {}
 
 
@@ -509,39 +490,31 @@ def parse_pe_symbols(symbols):
                 section_nb_str = str(
                     lief.PE.SYMBOL_SECTION_NUMBER(symbol.section_number)
                 ).rsplit(".", maxsplit=1)[-1]
+            elif symbol.section.name:
+                section_nb_str = symbol.section.name
             else:
-                try:
-                    section_nb_str = symbol.section.name
-                except AttributeError:
-                    section_nb_str = "section<{:d}>".format(
-                        symbol.section_number
-                    )
-        except (AttributeError, TypeError):
+                section_nb_str = "section<{:d}>".format(symbol.section_number)
+        except (AttributeError, TypeError) as e:
+            LOG.debug(f"Caught {type(e)}: {e} while parsing {symbol} PE symbol.")
             section_nb_str = ""
-        with contextlib.suppress(IndexError, AttributeError, ValueError):
+        try:
             if not exe_type:
-                try:
-                    exe_type = guess_exe_type(symbol.name.lower())
-                except AttributeError:
-                    exe_type = ""
+                exe_type = guess_exe_type(symbol.name.lower())
             if symbol.name:
                 symbols_list.append(
                     {
                         "name": symbol.name.replace("..", "::"),
                         "value": symbol.value,
                         "id": section_nb_str,
-                        "base_type": str(symbol.base_type).rsplit(
-                            ".", maxsplit=1
-                        )[-1],
-                        "complex_type": str(symbol.complex_type).rsplit(
-                            ".", maxsplit=1
-                        )[-1],
+                        "base_type": str(symbol.base_type).rsplit(".", maxsplit=1)[-1],
+                        "complex_type": str(symbol.complex_type).rsplit(".", maxsplit=1)[-1],
                         "storage_class": str(symbol.storage_class).rsplit(
-                            ".", maxsplit=1
-                        )[-1],
+                            ".", maxsplit=1)[-1],
                     }
                 )
-    return cleanup_list_lief_errors(symbols_list), exe_type
+        except (IndexError, AttributeError, ValueError) as e:
+            LOG.debug(f"Caught {type(e)}: {e} while parsing {symbol}.")
+    return symbols_list, exe_type
 
 
 def parse_pe_imports(imports):
@@ -559,10 +532,14 @@ def parse_pe_imports(imports):
     LOG.debug("Parsing imports")
     imports_list = []
     dlls = set()
+    if not imports or isinstance(imports, lief.lief_errors):
+        return imports_list, []
     for import_ in imports:
         try:
             entries = import_.entries
         except AttributeError:
+            break
+        if isinstance(entries, lief.lief_errors):
             break
         for entry in entries:
             try:
@@ -580,7 +557,7 @@ def parse_pe_imports(imports):
             except AttributeError:
                 continue
     dll_list = [{"name": d, "tag": "NEEDED"} for d in list(dlls)]
-    return cleanup_list_lief_errors(imports_list), cleanup_list_lief_errors(dll_list)
+    return imports_list, dll_list
 
 
 def parse_pe_exports(exports):
@@ -594,27 +571,30 @@ def parse_pe_exports(exports):
         list[dict]: A list of exported symbol dictionaries.
 
     """
+    LOG.debug("Parsing exports")
     exports_list = []
-    with contextlib.suppress(AttributeError):
-        LOG.debug("Parsing exports")
-        entries = exports.entries
+    if not exports or isinstance(exports, lief.lief_errors):
+        return exports_list
+    if not (entries := exports.entries) or isinstance(exports.entries, lief.lief_errors):
+        return exports_list
+    for entry in entries:
         metadata = {}
-        for entry in entries:
-            extern = "[EXTERN]" if entry.is_extern else ""
-            if entry.name:
-                metadata = {
-                    "name": entry.name,
-                    "ordinal": entry.ordinal,
-                    "address": ADDRESS_FMT.format(entry.address),
-                    "extern": extern,
-                }
-            fwd = entry.forward_information if entry.is_forwarded else None
-            metadata["is_forwarded"] = entry.is_forwarded
-            if fwd:
-                metadata["fwd_library"] = fwd.library
-                metadata["fwd_function"] = fwd.function
+        extern = "[EXTERN]" if entry.is_extern else ""
+        if entry.name:
+            metadata = {
+                "name": entry.name,
+                "ordinal": entry.ordinal,
+                "address": ADDRESS_FMT.format(entry.address),
+                "extern": extern,
+            }
+        fwd = entry.forward_information if entry.is_forwarded else None
+        metadata["is_forwarded"] = entry.is_forwarded
+        if fwd:
+            metadata["fwd_library"] = fwd.library
+            metadata["fwd_function"] = fwd.function
+        if metadata:
             exports_list.append(metadata)
-    return cleanup_list_lief_errors(exports_list)
+    return exports_list
 
 
 def parse_macho_symbols(symbols):
@@ -632,34 +612,28 @@ def parse_macho_symbols(symbols):
     LOG.debug("Parsing symbols")
     symbols_list = []
     exe_type = ""
-    if not symbols:
+    if not symbols or isinstance(symbols, lief.lief_errors):
         return symbols_list, exe_type
     for symbol in symbols:
         try:
             libname = ""
             if symbol.has_binding_info and symbol.binding_info.has_library:
                 libname = symbol.binding_info.library.name
-
             symbol_value = (
-                symbol.value
-                if symbol.value > 0 or not symbol.has_binding_info
-                else ADDRESS_FMT.format(symbol.binding_info.address)
+                symbol.value if symbol.value > 0 or not symbol.has_binding_info else
+                ADDRESS_FMT.format(
+                    symbol.binding_info.address
+                )
             )
-
-            try:
-                symbol_name = symbol.demangled_name
-            except AttributeError:
+            symbol_name = symbol.demangled_name
+            if not symbol_name or isinstance(symbol_name, lief.lief_errors):
                 symbol_name = symbol.name
             symbol_name = symbol_name.replace("..", "::")
             if not exe_type:
                 exe_type = guess_exe_type(symbol_name)
             symbols_list.append(
                 {
-                    "name": (
-                        f"{libname}::{symbol_name}"
-                        if libname
-                        else symbol_name
-                    ),
+                    "name": (f"{libname}::{symbol_name}" if libname else symbol_name),
                     "short_name": symbol_name,
                     "type": symbol.type,
                     "num_sections": symbol.numberof_sections,
@@ -669,7 +643,7 @@ def parse_macho_symbols(symbols):
             )
         except (AttributeError, TypeError):
             continue
-    return cleanup_list_lief_errors(symbols_list), exe_type
+    return symbols_list, exe_type
 
 
 def parse(exe_file):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -685,575 +659,630 @@ def parse(exe_file):  # pylint: disable=too-many-locals,too-many-branches,too-ma
         metadata["is_shared_library"] = is_shared_library(parsed_obj)
         # ELF Binary
         if isinstance(parsed_obj, lief.ELF.Binary):
-            metadata["binary_type"] = "ELF"
-            header = parsed_obj.header
-            identity = header.identity
-            eflags_str = ""
-            if header.machine_type == lief.ELF.ARCH.ARM:
-                eflags_str = " - ".join(
-                    [
-                        str(s).rsplit(".", maxsplit=1)[-1]
-                        for s in header.arm_flags_list
-                    ]
-                )
-            if header.machine_type in [
-                lief.ELF.ARCH.MIPS,
-                lief.ELF.ARCH.MIPS_RS3_LE,
-                lief.ELF.ARCH.MIPS_X,
-            ]:
-                eflags_str = " - ".join(
-                    [
-                        str(s).rsplit(".", maxsplit=1)[-1]
-                        for s in header.mips_flags_list
-                    ]
-                )
-            if header.machine_type == lief.ELF.ARCH.PPC64:
-                eflags_str = " - ".join(
-                    [
-                        str(s).rsplit(".", maxsplit=1)[-1]
-                        for s in header.ppc64_flags_list
-                    ]
-                )
-            if header.machine_type == lief.ELF.ARCH.HEXAGON:
-                eflags_str = " - ".join(
-                    [
-                        str(s).rsplit(".", maxsplit=1)[-1]
-                        for s in header.hexagon_flags_list
-                    ]
-                )
-            metadata["magic"] = ("{:<02x} " * 8).format(*identity[:8]).strip()
-            metadata["class"] = str(header.identity_class).rsplit(
-                ".", maxsplit=1
-            )[-1]
-            metadata["endianness"] = str(header.identity_data).rsplit(
-                ".", maxsplit=1
-            )[-1]
-            metadata["identity_version"] = str(header.identity_version).rsplit(
-                ".", maxsplit=1
-            )[-1]
-            metadata["identity_os_abi"] = str(header.identity_os_abi).rsplit(
-                ".", maxsplit=1
-            )[-1]
-            metadata["identity_abi_version"] = header.identity_abi_version
-            metadata["file_type"] = str(header.file_type).rsplit(
-                ".", maxsplit=1
-            )[-1]
-            metadata["machine_type"] = str(header.machine_type).rsplit(
-                ".", maxsplit=1
-            )[-1]
-            metadata["object_file_version"] = str(
-                header.object_file_version
-            ).rsplit(".", maxsplit=1)[-1]
-            metadata["entrypoint"] = header.entrypoint
-            metadata["processor_flag"] = str(header.processor_flag) + eflags_str
-            metadata["name"] = exe_file
-            metadata["imagebase"] = parsed_obj.imagebase
-            metadata["interpreter"] = parse_interpreter(parsed_obj)
-            metadata["is_pie"] = parsed_obj.is_pie
-            metadata["virtual_size"] = parsed_obj.virtual_size
-            metadata["has_nx"] = parsed_obj.has_nx
-            metadata["relro"] = parse_relro(parsed_obj)
-            metadata["exe_type"] = detect_exe_type(parsed_obj, metadata)
-            # Canary check
-            canary_sections = ["__stack_chk_fail", "__intel_security_cookie"]
-            for section in canary_sections:
-                if parsed_obj.get_symbol(section):
-                    if isinstance(
-                            parsed_obj.get_symbol(section), lief.lief_errors):
-                        metadata["has_canary"] = False
-                    else:
-                        metadata["has_canary"] = True
-                        break
-            # rpath check
-            rpath = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.RPATH)
-            if isinstance(rpath, lief.lief_errors):
-                metadata["has_rpath"] = False
-            elif rpath:
-                metadata["has_rpath"] = True
-            # runpath check
-            runpath = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.RUNPATH)
-            if isinstance(runpath, lief.lief_errors):
-                metadata["has_runpath"] = False
-            elif runpath:
-                metadata["has_runpath"] = True
-            static_symbols = parsed_obj.static_symbols
-            if static_symbols and not isinstance(
-                    static_symbols, lief.lief_errors):
-                metadata["static"] = True
-            dynamic_entries = parsed_obj.dynamic_entries
-            if dynamic_entries and not isinstance(
-                dynamic_entries, lief.lief_errors
-            ):
-                metadata["dynamic_entries"] = []
-                for entry in dynamic_entries:
-                    if entry.tag == lief.ELF.DYNAMIC_TAGS.NULL:
-                        continue
-                    if entry.tag in [
-                        lief.ELF.DYNAMIC_TAGS.SONAME,
-                        lief.ELF.DYNAMIC_TAGS.NEEDED,
-                        lief.ELF.DYNAMIC_TAGS.RUNPATH,
-                        lief.ELF.DYNAMIC_TAGS.RPATH,
-                    ]:
-                        metadata["dynamic_entries"].append(
-                            {
-                                "name": entry.name,
-                                "tag": str(entry.tag).rsplit(".", maxsplit=1)[
-                                    -1
-                                ],
-                                "value": entry.value,
-                            }
-                        )
-                        # Detect dotnet binary
-                        if "netcoredeps" in entry.name:
-                            metadata["exe_type"] = "dotnetbinary"
-            try:
-                symbols_version = parsed_obj.symbols_version
-                if len(symbols_version):
-                    metadata["symbols_version"] = []
-                    symbol_version_auxiliary_cache = {}
-                    for entry in symbols_version:
-                        symbol_version_auxiliary = (
-                            entry.symbol_version_auxiliary
-                        )
-                        if (
-                            symbol_version_auxiliary
-                            and not symbol_version_auxiliary_cache.get(
-                                symbol_version_auxiliary.name
-                            )
-                        ):
-                            symbol_version_auxiliary_cache[
-                                symbol_version_auxiliary.name
-                            ] = True
-                            metadata["symbols_version"].append(
-                                {
-                                    "name": symbol_version_auxiliary.name,
-                                    "hash": symbol_version_auxiliary.hash,
-                                    "value": entry.value,
-                                }
-                            )
-            except (AttributeError, TypeError):
-                metadata["symbols_version"] = []
-            try:
-                notes = parsed_obj.notes
-                if notes:
-                    metadata["notes"] = parse_notes(parsed_obj)
-            except (AttributeError, TypeError):
-                pass
-            metadata["strings"] = parse_strings(parsed_obj)
-            try:
-                metadata["static_symbols"], exe_type = parse_symbols(
-                    parsed_obj.static_symbols
-                )
-                if exe_type:
-                    metadata["exe_type"] = exe_type
-            except AttributeError:
-                pass
-            try:
-                metadata["dynamic_symbols"], exe_type = parse_symbols(
-                    parsed_obj.dynamic_symbols
-                )
-                if exe_type:
-                    metadata["exe_type"] = exe_type
-            except AttributeError:
-                pass
-            try:
-                metadata["functions"] = parse_functions(parsed_obj.functions)
-            except AttributeError:
-                pass
-            try:
-                metadata["ctor_functions"] = parse_functions(
-                    parsed_obj.ctor_functions
-                )
-            except AttributeError:
-                pass
+            metadata = add_elf_metadata(exe_file, metadata, parsed_obj)
         elif isinstance(parsed_obj, lief.PE.Binary):
             # PE
             # Parse header
-            try:
-                metadata["binary_type"] = "PE"
-                metadata["name"] = exe_file
-                metadata["is_pie"] = parsed_obj.is_pie
-                metadata["is_reproducible_build"] = (
-                    parsed_obj.is_reproducible_build
-                )
-                metadata["virtual_size"] = parsed_obj.virtual_size
-                metadata["has_nx"] = parsed_obj.has_nx
-                dos_header = parsed_obj.dos_header
-                metadata["magic"] = str(dos_header.magic)
-                header = parsed_obj.header
-                optional_header = parsed_obj.optional_header
-                metadata["used_bytes_in_the_last_page"] = (
-                    dos_header.used_bytes_in_last_page
-                )
-                metadata["file_size_in_pages"] = dos_header.file_size_in_pages
-                metadata["num_relocation"] = dos_header.numberof_relocation
-                metadata["header_size_in_paragraphs"] = (
-                    dos_header.header_size_in_paragraphs
-                )
-                metadata["minimum_extra_paragraphs"] = (
-                    dos_header.minimum_extra_paragraphs
-                )
-                metadata["maximum_extra_paragraphs"] = (
-                    dos_header.maximum_extra_paragraphs
-                )
-                metadata["initial_relative_ss"] = dos_header.initial_relative_ss
-                metadata["initial_sp"] = dos_header.initial_sp
-                metadata["checksum"] = dos_header.checksum
-                metadata["initial_ip"] = dos_header.initial_ip
-                metadata["initial_relative_cs"] = dos_header.initial_relative_cs
-                metadata["address_relocation_table"] = ADDRESS_FMT.format(
-                    dos_header.addressof_relocation_table
-                )
-                metadata["overlay_number"] = dos_header.overlay_number
-                metadata["oem_id"] = dos_header.oem_id
-                metadata["oem_info"] = dos_header.oem_info
-                metadata["address_new_exeheader"] = ADDRESS_FMT.format(
-                    dos_header.addressof_new_exeheader
-                )
-                metadata["characteristics"] = ", ".join(
-                    [
-                        str(chara).rsplit(".", maxsplit=1)[-1]
-                        for chara in header.characteristics_list
-                    ]
-                )
-                metadata["num_sections"] = header.numberof_sections
-                metadata["time_date_stamps"] = header.time_date_stamps
-                metadata["pointer_symbol_table"] = header.pointerto_symbol_table
-                metadata["num_symbols"] = header.numberof_symbols
-                metadata["size_optional_header"] = header.sizeof_optional_header
-                metadata["dll_characteristics"] = ", ".join(
-                    [
-                        str(chara).rsplit(".", maxsplit=1)[-1]
-                        for chara in optional_header.dll_characteristics_lists
-                    ]
-                )
-                metadata["subsystem"] = str(optional_header.subsystem).rsplit(
-                    ".", maxsplit=1
-                )[-1]
-                metadata["is_gui"] = metadata["subsystem"] == "WINDOWS_GUI"
-                metadata["exe_type"] = (
-                    "PE32"
-                    if optional_header.magic == lief.PE.PE_TYPE.PE32
-                    else "PE64"
-                )
-                metadata["major_linker_version"] = (
-                    optional_header.major_linker_version
-                )
-                metadata["minor_linker_version"] = (
-                    optional_header.minor_linker_version
-                )
-                metadata["sizeof_code"] = optional_header.sizeof_code
-                metadata["sizeof_initialized_data"] = (
-                    optional_header.sizeof_initialized_data
-                )
-                metadata["sizeof_uninitialized_data"] = (
-                    optional_header.sizeof_uninitialized_data
-                )
-                metadata["addressof_entrypoint"] = ADDRESS_FMT.format(
-                    optional_header.addressof_entrypoint
-                )
-                metadata["baseof_code"] = optional_header.baseof_code
-                metadata["baseof_data"] = optional_header.baseof_data
-                metadata["imagebase"] = optional_header.imagebase
-                metadata["section_alignment"] = (
-                    optional_header.section_alignment
-                )
-                metadata["file_alignment"] = optional_header.file_alignment
-                metadata["major_operating_system_version"] = (
-                    optional_header.major_operating_system_version
-                )
-                metadata["minor_operating_system_version"] = (
-                    optional_header.minor_operating_system_version
-                )
-                metadata["major_image_version"] = (
-                    optional_header.major_image_version
-                )
-                metadata["minor_image_version"] = (
-                    optional_header.minor_image_version
-                )
-                metadata["major_subsystem_version"] = (
-                    optional_header.major_subsystem_version
-                )
-                metadata["minor_subsystem_version"] = (
-                    optional_header.minor_subsystem_version
-                )
-                metadata["win32_version_value"] = (
-                    optional_header.win32_version_value
-                )
-                metadata["sizeof_image"] = optional_header.sizeof_image
-                metadata["sizeof_headers"] = optional_header.sizeof_headers
-                metadata["checksum"] = optional_header.checksum
-                metadata["sizeof_stack_reserve"] = (
-                    optional_header.sizeof_stack_reserve
-                )
-                metadata["sizeof_stack_commit"] = (
-                    optional_header.sizeof_stack_commit
-                )
-                metadata["sizeof_heap_reserve"] = (
-                    optional_header.sizeof_heap_reserve
-                )
-                metadata["sizeof_heap_commit"] = (
-                    optional_header.sizeof_heap_commit
-                )
-                metadata["loader_flags"] = optional_header.loader_flags
-                metadata["numberof_rva_and_size"] = (
-                    optional_header.numberof_rva_and_size
-                )
-            except Exception:
-                pass
-                metadata["data_directories"] = parse_pe_data(parsed_obj)
-                metadata["authenticode"] = parse_pe_authenticode(parsed_obj)
-                metadata["signatures"] = process_pe_signature(parsed_obj)
-                metadata["resources"] = process_pe_resources(parsed_obj)
-
-            try:
-                metadata["static_symbols"], exe_type = parse_pe_symbols(
-                    parsed_obj.symbols
-                )
-                if exe_type:
-                    metadata["exe_type"] = exe_type
-            except AttributeError:
-                pass
-            try:
-                (
-                    metadata["imports"],
-                    metadata["dynamic_entries"],
-                ) = parse_pe_imports(parsed_obj.imports)
-            except AttributeError:
-                pass
-            try:
-                metadata["exports"] = parse_pe_exports(parsed_obj.get_export())
-            except AttributeError:
-                pass
-            try:
-                metadata["functions"] = parse_functions(parsed_obj.functions)
-            except AttributeError:
-                pass
-            try:
-                metadata["ctor_functions"] = parse_functions(
-                    parsed_obj.ctor_functions
-                )
-            except AttributeError:
-                pass
-            try:
-                metadata["exception_functions"] = parse_functions(
-                    parsed_obj.exception_functions
-                )
-            except AttributeError:
-                pass
-            try:
-                tls = parsed_obj.tls
-                if tls and tls.sizeof_zero_fill:
-                    metadata["tls_address_index"] = tls.addressof_index
-                    metadata["tls_sizeof_zero_fill"] = tls.sizeof_zero_fill
-                    metadata["tls_data_template_len"] = len(tls.data_template)
-                    metadata["tls_characteristics"] = tls.characteristics
-                    metadata["tls_section_name"] = tls.section.name
-                    metadata["tls_directory_type"] = str(tls.directory.type)
-            except (AttributeError, TypeError):
-                pass
+            metadata = add_pe_metadata(exe_file, metadata, parsed_obj)
         elif isinstance(parsed_obj, lief.MachO.Binary):
-            # MachO
-            metadata["binary_type"] = "MachO"
-            metadata["name"] = exe_file
-            metadata["imagebase"] = parsed_obj.imagebase
-            metadata["is_pie"] = parsed_obj.is_pie
-            metadata["has_nx"] = parsed_obj.has_nx
-            metadata["exe_type"] = "MachO"
-            try:
-                version = (
-                    parsed_obj.version_min.version
-                    if parsed_obj.version_min
-                    else None
-                )
-                sdk = (
-                    parsed_obj.version_min.sdk
-                    if parsed_obj.version_min
-                    else None
-                )
-                source_version = (
-                    parsed_obj.source_version.version
-                    if parsed_obj.source_version
-                    else None
-                )
-                if source_version:
-                    metadata["source_version"] = (
-                        "{:d}.{:d}.{:d}.{:d}.{:d}".format(*source_version)
-                    )
-                if version:
-                    metadata["version"] = "{:d}.{:d}.{:d}".format(*version)
-                if sdk:
-                    metadata["sdk"] = "{:d}.{:d}.{:d}".format(*sdk)
-            except Exception:
-                pass
-            try:
-                build_version = parsed_obj.build_version
-                if build_version:
-                    metadata["platform"] = str(build_version.platform).rsplit(
-                        ".", maxsplit=1
-                    )[-1]
-                    metadata["minos"] = "{:d}.{:d}.{:d}".format(
-                        *build_version.minos
-                    )
-                    metadata["sdk"] = "{:d}.{:d}.{:d}".format(
-                        *build_version.sdk
-                    )
-                    tools = build_version.tools
-                    if len(tools) > 0:
-                        metadata["tools"] = []
-                        for tool in tools:
-                            tool_str = str(tool.tool).rsplit(".", maxsplit=1)[
-                                -1
-                            ]
-                            metadata["tools"].append(
-                                {
-                                    "tool": tool_str,
-                                    "version": "{}.{}.{}".format(*tool.version),
-                                }
-                            )
-            except Exception:
-                pass
-            try:
-                if parsed_obj.has_encryption_info:
-                    encryption_info = parsed_obj.encryption_info
-                    if encryption_info:
-                        metadata["encryption_info"] = {
-                            "crypt_offset": encryption_info.crypt_offset,
-                            "crypt_size": encryption_info.crypt_size,
-                            "crypt_id": encryption_info.crypt_id,
-                        }
-            except Exception:
-                pass
-            try:
-                sinfo = parsed_obj.sub_framework
-                if sinfo:
-                    metadata["umbrella"] = sinfo.umbrella
-            except Exception:
-                pass
-            try:
-                cmd = parsed_obj.rpath
-                if cmd:
-                    metadata["has_rpath"] = True
-                    metadata["rpath"] = cmd.path
-            except Exception:
-                metadata["has_rpath"] = False
-            try:
-                cmd = parsed_obj.uuid
-                if cmd:
-                    uuid_str = " ".join(map(integer_to_hex_str, cmd.uuid))
-                    metadata["uuid"] = str(uuid_str)
-            except Exception:
-                pass
-            try:
-                if parsed_obj.libraries:
-                    metadata["libraries"] = []
-                    for library in parsed_obj.libraries:
-                        current_version_str = "{:d}.{:d}.{:d}".format(
-                            *library.current_version
-                        )
-                        compat_version_str = "{:d}.{:d}.{:d}".format(
-                            *library.compatibility_version
-                        )
-                        metadata["libraries"].append(
-                            {
-                                "name": library.name,
-                                "timestamp": library.timestamp,
-                                "version": current_version_str,
-                                "compatibility_version": compat_version_str,
-                            }
-                        )
-            except Exception:
-                pass
-            try:
-                header = parsed_obj.header
-                flags_str = ", ".join(
-                    [
-                        str(s).rsplit(".", maxsplit=1)[-1]
-                        for s in header.flags_list
-                    ]
-                )
-                metadata["magic"] = str(header.magic).rsplit(".", maxsplit=1)[
-                    -1
-                ]
-                metadata["cpu_type"] = str(header.cpu_type).rsplit(
-                    ".", maxsplit=1
-                )[-1]
-                metadata["cpu_subtype"] = header.cpu_subtype
-                metadata["file_type"] = str(header.file_type).rsplit(
-                    ".", maxsplit=1
-                )[-1]
-                metadata["flags"] = flags_str
-                metadata["number_commands"] = header.nb_cmds
-                metadata["size_commands"] = header.sizeof_cmds
-                metadata["reserved"] = header.reserved
-            except Exception:
-                pass
-            try:
-                if parsed_obj.main_command:
-                    metadata["has_main_command"] = (
-                        False if isinstance(
-                            parsed_obj.main_command, lief.lief_errors)
-                        else True
-                    )
-                if parsed_obj.thread_command:
-                    metadata["has_thread_command"] = (
-                        False if isinstance(
-                            parsed_obj.thread_command, lief.lief_errors)
-                        else True
-                    )
-            except AttributeError:
-                metadata["has_main"] = False
-                metadata["has_thread_command"] = False
-            with contextlib.suppress(AttributeError):
-                metadata["functions"] = parse_functions(parsed_obj.functions)
-                metadata["ctor_functions"] = parse_functions(
-                    parsed_obj.ctor_functions
-                )
-                metadata["unwind_functions"] = parse_functions(
-                    parsed_obj.unwind_functions
-                )
-                metadata["static_symbols"], exe_type = parse_macho_symbols(
-                    parsed_obj.symbols
-                )
-                if exe_type:
-                    metadata["exe_type"] = exe_type
-                if parsed_obj.dylinker:
-                    metadata["dylinker"] = parsed_obj.dylinker.name
-            with contextlib.suppress(AttributeError, TypeError):
-                if parsed_obj.has_code_signature:
-                    code_signature = parsed_obj.code_signature
-                    metadata["code_signature"] = {
-                        "available": code_signature.size > 0,
-                        "data": str(code_signature.data.hex()),
-                        "data_size": str(code_signature.data_size),
-                        "size": str(code_signature.size),
-                    }
-                if (
-                    not parsed_obj.has_code_signature
-                    and parsed_obj.has_code_signature_dir
-                ):
-                    code_signature = parsed_obj.code_signature_dir
-                    metadata["code_signature"] = {
-                        "available": code_signature.size > 0,
-                        "data": str(code_signature.data.hex()),
-                        "data_size": str(code_signature.data_size),
-                        "size": str(code_signature.size),
-                    }
-                if (
-                    not parsed_obj.has_code_signature
-                    and not parsed_obj.has_code_signature_dir
-                ):
-                    metadata["code_signature"] = {"available": False}
-                if parsed_obj.has_data_in_code:
-                    data_in_code = parsed_obj.data_in_code
-                    metadata["data_in_code"] = {
-                        "data": str(data_in_code.data.hex()),
-                        "data_size": str(data_in_code.data_size),
-                        "size": str(data_in_code.size),
-                    }
+            metadata = add_mach0_metadata(exe_file, metadata, parsed_obj)
     except (AttributeError, TypeError, ValueError) as e:
-        LOG.exception(e)
+        LOG.exception(f"Caught {type(e)}: {e} while parsing {exe_file}.")
     return cleanup_dict_lief_errors(metadata)
+
+
+def add_elf_metadata(exe_file, metadata, parsed_obj):
+    """Adds ELF metadata to the given metadata dictionary.
+
+    Args:
+        exe_file (str): The path of the executable file.
+        metadata (dict): The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the ELF binary.
+
+    Returns:
+        dict: The updated metadata dictionary.
+    """
+    metadata["binary_type"] = "ELF"
+    header = parsed_obj.header
+    identity = header.identity
+    metadata["magic"] = ("{:<02x} " * 8).format(*identity[:8]).strip()
+    metadata = add_elf_header(header, metadata)
+    metadata["name"] = exe_file
+    metadata["imagebase"] = parsed_obj.imagebase
+    metadata["interpreter"] = parsed_obj.interpreter
+    metadata["is_pie"] = parsed_obj.is_pie
+    metadata["virtual_size"] = parsed_obj.virtual_size
+    metadata["has_nx"] = parsed_obj.has_nx
+    metadata["relro"] = parse_relro(parsed_obj)
+    metadata["exe_type"] = detect_exe_type(parsed_obj, metadata)
+    # Canary check
+    canary_sections = ["__stack_chk_fail", "__intel_security_cookie"]
+    for section in canary_sections:
+        if parsed_obj.get_symbol(section):
+            if isinstance(parsed_obj.get_symbol(section), lief.lief_errors):
+                metadata["has_canary"] = False
+            else:
+                metadata["has_canary"] = True
+                break
+    # rpath check
+    rpath = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.RPATH)
+    if isinstance(rpath, lief.lief_errors):
+        metadata["has_rpath"] = False
+    elif rpath:
+        metadata["has_rpath"] = True
+    # runpath check
+    runpath = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.RUNPATH)
+    if isinstance(runpath, lief.lief_errors):
+        metadata["has_runpath"] = False
+    elif runpath:
+        metadata["has_runpath"] = True
+    static_symbols = parsed_obj.static_symbols
+    metadata["static"] = bool(static_symbols and not isinstance(static_symbols, lief.lief_errors))
+    dynamic_entries = parsed_obj.dynamic_entries
+    metadata = add_elf_dynamic_entries(dynamic_entries, metadata)
+    metadata = add_elf_symbols(metadata, parsed_obj)
+    metadata["notes"] = parse_notes(parsed_obj)
+    metadata["strings"] = parse_strings(parsed_obj)
+    metadata["static_symbols"], exe_type = parse_symbols(
+        parsed_obj.static_symbols
+    )
+    if exe_type:
+        metadata["exe_type"] = exe_type
+    metadata["dynamic_symbols"], exe_type = parse_symbols(
+        parsed_obj.dynamic_symbols
+    )
+    if exe_type:
+        metadata["exe_type"] = exe_type
+    metadata["functions"] = parse_functions(parsed_obj.functions)
+
+    metadata["ctor_functions"] = parse_functions(parsed_obj.ctor_functions)
+
+    return metadata
+
+
+def add_elf_header(header, metadata):
+    """Adds ELF header data to the metadata dictionary.
+
+    Args:
+        header: The ELF header.
+        metadata: The dictionary to store the metadata.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    if not header or isinstance(header, lief.lief_errors):
+        return metadata
+    try:
+        eflags_str = determine_elf_flags(header)
+        metadata["class"] = str(header.identity_class).rsplit(".", maxsplit=1)[-1]
+        metadata["endianness"] = str(header.identity_data).rsplit(".", maxsplit=1)[-1]
+        metadata["identity_version"] = str(
+            header.identity_version
+        ).rsplit(".", maxsplit=1)[-1]
+        metadata["identity_os_abi"] = str(
+            header.identity_os_abi
+        ).rsplit(".", maxsplit=1)[-1]
+        metadata["identity_abi_version"] = header.identity_abi_version
+        metadata["file_type"] = str(header.file_type).rsplit(".", maxsplit=1)[-1]
+        metadata["machine_type"] = str(header.machine_type).rsplit(".", maxsplit=1)[-1]
+        metadata["object_file_version"] = str(
+            header.object_file_version
+        ).rsplit(".", maxsplit=1)[-1]
+        metadata["entrypoint"] = header.entrypoint
+        metadata["processor_flag"] = str(header.processor_flag) + eflags_str
+    except (AttributeError, TypeError, ValueError) as e:
+        LOG.debug(f"Caught {type(e)}: {e} while parsing elf headers.")
+    return metadata
+
+
+def add_elf_symbols(metadata, parsed_obj):
+    """Extracts ELF symbols version information and adds it to the metadata dictionary.
+
+    Args:
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the ELF binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    try:
+        symbols_version = parsed_obj.symbols_version
+        if symbols_version and not isinstance(symbols_version, lief.lief_errors):
+            metadata["symbols_version"] = []
+            symbol_version_auxiliary_cache = {}
+            for entry in symbols_version:
+                symbol_version_auxiliary = entry.symbol_version_auxiliary
+                if (symbol_version_auxiliary and not symbol_version_auxiliary_cache.get(
+                    symbol_version_auxiliary.name
+                )):
+                    symbol_version_auxiliary_cache[symbol_version_auxiliary.name] = True
+                    metadata["symbols_version"].append(
+                        {
+                            "name": symbol_version_auxiliary.name,
+                            "hash": symbol_version_auxiliary.hash,
+                            "value": entry.value,
+                        }
+                    )
+    except (AttributeError, TypeError) as e:
+        LOG.debug(f"Caught {type(e)}: {e} while parsing elf symbols.")
+        metadata["symbols_version"] = []
+    return metadata
+
+
+def add_elf_dynamic_entries(dynamic_entries, metadata):
+    """Extracts ELF dynamic entries and adds them to the metadata dictionary.
+
+    Args:
+        dynamic_entries: The dynamic entries of the ELF binary.
+        metadata: The dictionary to store the metadata.
+
+    Returns:
+        dict: The updated metadata dictionary.
+    """
+    metadata["dynamic_entries"] = []
+    if isinstance(dynamic_entries, lief.lief_errors):
+        return metadata
+    for entry in dynamic_entries:
+        if entry.tag == lief.ELF.DYNAMIC_TAGS.NULL:
+            continue
+        if entry.tag in [lief.ELF.DYNAMIC_TAGS.SONAME, lief.ELF.DYNAMIC_TAGS.NEEDED,
+                         lief.ELF.DYNAMIC_TAGS.RUNPATH, lief.ELF.DYNAMIC_TAGS.RPATH, ]:
+            metadata["dynamic_entries"].append(
+                {
+                    "name": entry.name,
+                    "tag": str(entry.tag).rsplit(".", maxsplit=1)[-1],
+                    "value": entry.value,
+                }
+            )
+            # Detect dotnet binary
+            if "netcoredeps" in entry.name:
+                metadata["exe_type"] = "dotnetbinary"
+    return metadata
+
+
+def determine_elf_flags(header):
+    """Determines the ELF flags based on the given ELF header.
+    Args:
+        header: The ELF header.
+
+    Returns:
+        A string representing the ELF flags.
+    """
+    eflags_str = ""
+    if header.machine_type == lief.ELF.ARCH.ARM:
+        eflags_str = " - ".join(
+            [str(s).rsplit(".", maxsplit=1)[-1] for s in header.arm_flags_list]
+        )
+    if header.machine_type in [lief.ELF.ARCH.MIPS, lief.ELF.ARCH.MIPS_RS3_LE,
+                               lief.ELF.ARCH.MIPS_X, ]:
+        eflags_str = " - ".join(
+            [str(s).rsplit(".", maxsplit=1)[-1] for s in header.mips_flags_list]
+        )
+    if header.machine_type == lief.ELF.ARCH.PPC64:
+        eflags_str = " - ".join(
+            [str(s).rsplit(".", maxsplit=1)[-1] for s in header.ppc64_flags_list]
+        )
+    if header.machine_type == lief.ELF.ARCH.HEXAGON:
+        eflags_str = " - ".join(
+            [str(s).rsplit(".", maxsplit=1)[-1] for s in header.hexagon_flags_list]
+        )
+    return eflags_str
+
+
+def add_pe_metadata(exe_file, metadata, parsed_obj):
+    """Adds PE metadata to the given metadata dictionary.
+
+    Args:
+        exe_file (str): The path of the executable file.
+        metadata (dict): The dictionary to store the metadata.
+        parsed_obj (lief.PE.Binary): The parsed object representing the PE binary.
+
+    Returns:
+        dict: The updated metadata dictionary.
+
+    Raises:
+        AttributeError: If the parsed object does not have the required attributes.
+        IndexError: If there is an index error while accessing attributes.
+        TypeError: If there is a type error while accessing attributes.
+        ValueError: If there is a value error while accessing attributes.
+    """
+    try:
+        metadata["binary_type"] = "PE"
+        metadata["name"] = exe_file
+        metadata["is_pie"] = parsed_obj.is_pie
+        metadata["is_reproducible_build"] = parsed_obj.is_reproducible_build
+        metadata["virtual_size"] = parsed_obj.virtual_size
+        metadata["has_nx"] = parsed_obj.has_nx
+        metadata = add_pe_header_data(metadata, parsed_obj)
+        metadata["data_directories"] = parse_pe_data(parsed_obj)
+        metadata["authenticode"] = parse_pe_authenticode(parsed_obj)
+        metadata["signatures"] = process_pe_signature(parsed_obj)
+        metadata["resources"] = process_pe_resources(parsed_obj)
+        metadata["static_symbols"], exe_type = parse_pe_symbols(
+            parsed_obj.symbols
+        )
+        if exe_type:
+            metadata["exe_type"] = exe_type
+        (metadata["imports"], metadata["dynamic_entries"],) = parse_pe_imports(
+            parsed_obj.imports
+        )
+        metadata["exports"] = parse_pe_exports(parsed_obj.get_export())
+        metadata["functions"] = parse_functions(parsed_obj.functions)
+        metadata["ctor_functions"] = parse_functions(parsed_obj.ctor_functions)
+        metadata["exception_functions"] = parse_functions(
+            parsed_obj.exception_functions
+        )
+        tls = parsed_obj.tls
+        if tls and tls.sizeof_zero_fill:
+            metadata["tls_address_index"] = tls.addressof_index
+            metadata["tls_sizeof_zero_fill"] = tls.sizeof_zero_fill
+            metadata["tls_data_template_len"] = len(tls.data_template)
+            metadata["tls_characteristics"] = tls.characteristics
+            metadata["tls_section_name"] = tls.section.name
+            metadata["tls_directory_type"] = str(tls.directory.type)
+    except (AttributeError, IndexError, TypeError, ValueError) as e:
+        LOG.debug(f"Caught {type(e)}: {e} while parsing {exe_file} PE metadata.")
+    return metadata
+
+
+def add_pe_header_data(metadata, parsed_obj):
+    """Adds PE header data to the metadata dictionary.
+
+    Args:
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the PE binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    dos_header = parsed_obj.dos_header
+    if dos_header and not isinstance(dos_header, lief.lief_errors):
+        with contextlib.suppress(IndexError, TypeError):
+            metadata["magic"] = str(dos_header.magic)
+            header = parsed_obj.header
+            metadata["used_bytes_in_the_last_page"] = dos_header.used_bytes_in_last_page
+            metadata["file_size_in_pages"] = dos_header.file_size_in_pages
+            metadata["num_relocation"] = dos_header.numberof_relocation
+            metadata["header_size_in_paragraphs"] = dos_header.header_size_in_paragraphs
+            metadata["minimum_extra_paragraphs"] = dos_header.minimum_extra_paragraphs
+            metadata["maximum_extra_paragraphs"] = dos_header.maximum_extra_paragraphs
+            metadata["initial_relative_ss"] = dos_header.initial_relative_ss
+            metadata["initial_sp"] = dos_header.initial_sp
+            metadata["checksum"] = dos_header.checksum
+            metadata["initial_ip"] = dos_header.initial_ip
+            metadata["initial_relative_cs"] = dos_header.initial_relative_cs
+            metadata["address_relocation_table"] = ADDRESS_FMT.format(
+                dos_header.addressof_relocation_table
+            )
+            metadata["overlay_number"] = dos_header.overlay_number
+            metadata["oem_id"] = dos_header.oem_id
+            metadata["oem_info"] = dos_header.oem_info
+            metadata["address_new_exeheader"] = ADDRESS_FMT.format(
+                dos_header.addressof_new_exeheader
+            )
+            metadata["characteristics"] = ", ".join(
+                [str(chara).rsplit(".", maxsplit=1)[-1] for chara in header.characteristics_list]
+            )
+            metadata["num_sections"] = header.numberof_sections
+            metadata["time_date_stamps"] = header.time_date_stamps
+            metadata["pointer_symbol_table"] = header.pointerto_symbol_table
+            metadata["num_symbols"] = header.numberof_symbols
+            metadata["size_optional_header"] = header.sizeof_optional_header
+    optional_header = parsed_obj.optional_header
+    if optional_header and not isinstance(optional_header, lief.lief_errors):
+        metadata = add_pe_optional_headers(metadata, optional_header)
+    return metadata
+
+
+def add_pe_optional_headers(metadata, optional_header):
+    """Adds PE optional headers data to the metadata dictionary.
+
+    Args:
+        metadata: The dictionary to store the metadata.
+        optional_header: The optional header of the PE binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    with contextlib.suppress(IndexError, TypeError):
+        metadata["dll_characteristics"] = ", ".join(
+            [str(chara).rsplit(".", maxsplit=1)[-1] for chara in
+             optional_header.dll_characteristics_lists]
+        )
+        metadata["subsystem"] = str(optional_header.subsystem).rsplit(
+            ".", maxsplit=1
+        )[-1]
+        metadata["is_gui"] = metadata["subsystem"] == "WINDOWS_GUI"
+        metadata["exe_type"] = (
+            "PE32" if optional_header.magic == lief.PE.PE_TYPE.PE32 else "PE64")
+        metadata["major_linker_version"] = optional_header.major_linker_version
+        metadata["minor_linker_version"] = optional_header.minor_linker_version
+        metadata["sizeof_code"] = optional_header.sizeof_code
+        metadata["sizeof_initialized_data"] = optional_header.sizeof_initialized_data
+        metadata["sizeof_uninitialized_data"] = optional_header.sizeof_uninitialized_data
+        metadata["addressof_entrypoint"] = ADDRESS_FMT.format(
+            optional_header.addressof_entrypoint
+        )
+        metadata["baseof_code"] = optional_header.baseof_code
+        metadata["baseof_data"] = optional_header.baseof_data
+        metadata["imagebase"] = optional_header.imagebase
+        metadata["section_alignment"] = optional_header.section_alignment
+        metadata["file_alignment"] = optional_header.file_alignment
+        metadata["major_operating_system_version"] = (
+            optional_header.major_operating_system_version)
+        metadata["minor_operating_system_version"] = (
+            optional_header.minor_operating_system_version)
+        metadata["major_image_version"] = optional_header.major_image_version
+        metadata["minor_image_version"] = optional_header.minor_image_version
+        metadata["major_subsystem_version"] = optional_header.major_subsystem_version
+        metadata["minor_subsystem_version"] = optional_header.minor_subsystem_version
+        metadata["win32_version_value"] = optional_header.win32_version_value
+        metadata["sizeof_image"] = optional_header.sizeof_image
+        metadata["sizeof_headers"] = optional_header.sizeof_headers
+        metadata["checksum"] = optional_header.checksum
+        metadata["sizeof_stack_reserve"] = optional_header.sizeof_stack_reserve
+        metadata["sizeof_stack_commit"] = optional_header.sizeof_stack_commit
+        metadata["sizeof_heap_reserve"] = optional_header.sizeof_heap_reserve
+        metadata["sizeof_heap_commit"] = optional_header.sizeof_heap_commit
+        metadata["loader_flags"] = optional_header.loader_flags
+        metadata["numberof_rva_and_size"] = optional_header.numberof_rva_and_size
+    return metadata
+
+
+def add_mach0_metadata(exe_file, metadata, parsed_obj):
+    """Adds MachO metadata to the given metadata dictionary.
+
+    Args:
+        exe_file: The path of the executable file.
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the MachO binary.
+
+    Returns:
+        dict: The updated metadata dictionary.
+    """
+    metadata["binary_type"] = "MachO"
+    metadata["name"] = exe_file
+    metadata["imagebase"] = parsed_obj.imagebase
+    metadata["is_pie"] = parsed_obj.is_pie
+    metadata["has_nx"] = parsed_obj.has_nx
+    metadata["exe_type"] = "MachO"
+    metadata = add_mach0_versions(exe_file, metadata, parsed_obj)
+    if parsed_obj.has_encryption_info and (encryption_info := parsed_obj.encryption_info):
+        metadata["encryption_info"] = {
+            "crypt_offset": encryption_info.crypt_offset,
+            "crypt_size": encryption_info.crypt_size,
+            "crypt_id": encryption_info.crypt_id,
+        }
+    if sinfo := parsed_obj.sub_framework:
+        metadata["umbrella"] = sinfo.umbrella
+    if cmd := parsed_obj.rpath:
+        metadata["has_rpath"] = True
+        metadata["rpath"] = cmd.path
+    else:
+        metadata["has_rpath"] = False
+    try:
+        if cmd := parsed_obj.uuid:
+            uuid_str = " ".join(map(integer_to_hex_str, cmd.uuid))
+            metadata["uuid"] = uuid_str
+    except (AttributeError, TypeError, ValueError) as e:
+        LOG.debug(f"Caught {type(e)}: {e} while parsing {exe_file} Mach0 UUID.")
+    metadata = add_mach0_libraries(exe_file, metadata, parsed_obj)
+    metadata = add_mach0_header_data(exe_file, metadata, parsed_obj)
+    metadata = add_mach0_commands(metadata, parsed_obj)
+    metadata = add_mach0_functions(metadata, parsed_obj)
+    metadata = add_mach0_signature(exe_file, metadata, parsed_obj)
+    return metadata
+
+
+def add_mach0_commands(metadata, parsed_obj):
+    """Extracts MachO commands metadata from the parsed object and adds it to the metadata.
+
+    Args:
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the MachO binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    metadata["has_main"] = False
+    metadata["has_thread_command"] = False
+    if parsed_obj.main_command:
+        metadata["has_main_command"] = not isinstance(
+            parsed_obj.main_command, lief.lief_errors
+        )
+    if parsed_obj.thread_command:
+        metadata["has_thread_command"] = not isinstance(
+            parsed_obj.thread_command, lief.lief_errors
+        )
+
+    return metadata
+
+
+def add_mach0_versions(exe_file, metadata, parsed_obj):
+    """Extracts MachO version metadata from the parsed object and adds it to the metadata.
+
+    Args:
+        exe_file: The path of the executable file.
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the MachO binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    try:
+        version = (parsed_obj.version_min.version if parsed_obj.version_min else "")
+        sdk = (parsed_obj.version_min.sdk if parsed_obj.version_min else "")
+        source_version = (parsed_obj.source_version.version if parsed_obj.source_version else "")
+        if source_version:
+            metadata["source_version"] = "{:d}.{:d}.{:d}.{:d}.{:d}".format(*source_version)
+        if version:
+            metadata["version"] = "{:d}.{:d}.{:d}".format(*version)
+        if sdk:
+            metadata["sdk"] = "{:d}.{:d}.{:d}".format(*sdk)
+    except (AttributeError, IndexError, TypeError) as e:
+        LOG.debug(f"Caught {type(e)}: {e} while parsing {exe_file} Mach0 version metadata.")
+    return add_mach0_build_metadata(exe_file, metadata, parsed_obj)
+
+
+def add_mach0_build_metadata(exe_file, metadata, parsed_obj):
+    """Extracts MachO build version metadata from the parsed object and adds it to the metadata.
+
+    Args:
+        exe_file: The path of the executable file.
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the MachO binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    try:
+        build_version = parsed_obj.build_version
+        if not build_version:
+            return metadata
+        metadata["platform"] = str(build_version.platform).rsplit(".", maxsplit=1)[-1]
+        metadata["minos"] = "{:d}.{:d}.{:d}".format(*build_version.minos)
+        metadata["sdk"] = "{:d}.{:d}.{:d}".format(*build_version.sdk)
+        if tools := build_version.tools:
+            metadata["tools"] = []
+            for tool in tools:
+                tool_str = str(tool.tool).rsplit(".", maxsplit=1)[-1]
+                metadata["tools"].append(
+                    {
+                        "tool": tool_str, "version": "{}.{}.{}".format(*tool.version),
+                    }
+                )
+    except (AttributeError, IndexError, TypeError) as e:
+        LOG.debug(f"Caught {type(e)}: {e} while parsing {exe_file} Mach0 build version metadata.")
+    return metadata
+
+
+def add_mach0_libraries(exe_file, metadata, parsed_obj):
+    """Processes the libraries of a MachO binary and adds them to the metadata dictionary.
+
+    Args:
+        exe_file: The path of the executable file.
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the MachO binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    try:
+        metadata["libraries"] = []
+        if not parsed_obj.libraries:
+            return metadata
+        for library in parsed_obj.libraries:
+            current_version_str = "{:d}.{:d}.{:d}".format(
+                *library.current_version
+            )
+            compat_version_str = "{:d}.{:d}.{:d}".format(
+                *library.compatibility_version
+            )
+            metadata["libraries"].append(
+                {
+                    "name": library.name,
+                    "timestamp": library.timestamp,
+                    "version": current_version_str,
+                    "compatibility_version": compat_version_str,
+                }
+            )
+    except (AttributeError, IndexError, ValueError) as e:
+        LOG.debug(f"Caught {type(e)}: {e} while parsing {exe_file} Mach0 libraries.")
+    return metadata
+
+
+def add_mach0_header_data(exe_file, metadata, parsed_obj):
+    """Extracts MachO header data from the parsed object and adds it to the metadata dictionary.
+
+    Args:
+        exe_file: The path of the executable file.
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the MachO binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    try:
+        header = parsed_obj.header
+        flags_str = ", ".join([str(s).rsplit(".", maxsplit=1)[-1] for s in header.flags_list])
+        metadata["magic"] = str(header.magic).rsplit(".", maxsplit=1)[-1]
+        metadata["cpu_type"] = str(header.cpu_type).rsplit(".", maxsplit=1)[-1]
+        metadata["cpu_subtype"] = header.cpu_subtype
+        metadata["file_type"] = str(header.file_type).rsplit(".", maxsplit=1)[-1]
+        metadata["flags"] = flags_str
+        metadata["number_commands"] = header.nb_cmds
+        metadata["size_commands"] = header.sizeof_cmds
+        metadata["reserved"] = header.reserved
+    except (AttributeError, IndexError, TypeError) as e:
+        LOG.debug(f"Caught {type(e)}: {e} while parsing {exe_file} Mach0 header.")
+    return metadata
+
+
+def add_mach0_functions(metadata, parsed_obj):
+    """Extracts MachO functions and symbols from the parsed object and adds them to the metadata.
+
+    Args:
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the MachO binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    metadata["functions"] = parse_functions(parsed_obj.functions)
+    metadata["ctor_functions"] = parse_functions(parsed_obj.ctor_functions)
+    metadata["unwind_functions"] = parse_functions(
+        parsed_obj.unwind_functions
+    )
+    metadata["static_symbols"], exe_type = parse_macho_symbols(
+        parsed_obj.symbols
+    )
+    if exe_type:
+        metadata["exe_type"] = exe_type
+    if parsed_obj.dylinker:
+        metadata["dylinker"] = parsed_obj.dylinker.name
+    return metadata
+
+
+def add_mach0_signature(exe_file, metadata, parsed_obj):
+    """Extracts MachO code signature metadata from the parsed object and adds it to the metadata.
+
+    Args:
+        exe_file: The path of the executable file.
+        metadata: The dictionary to store the metadata.
+        parsed_obj: The parsed object representing the MachO binary.
+
+    Returns:
+        The updated metadata dictionary.
+    """
+    try:
+        if parsed_obj.has_code_signature:
+            code_signature = parsed_obj.code_signature
+            metadata["code_signature"] = {
+                "available": code_signature.size > 0,
+                "data": str(code_signature.data.hex()),
+                "data_size": str(code_signature.data_size),
+                "size": str(code_signature.size),
+            }
+        if not parsed_obj.has_code_signature and parsed_obj.has_code_signature_dir:
+            code_signature = parsed_obj.code_signature_dir
+            metadata["code_signature"] = {
+                "available": code_signature.size > 0,
+                "data": str(code_signature.data.hex()),
+                "data_size": str(code_signature.data_size),
+                "size": str(code_signature.size),
+            }
+        if not parsed_obj.has_code_signature and not parsed_obj.has_code_signature_dir:
+            metadata["code_signature"] = {"available": False}
+        if parsed_obj.has_data_in_code:
+            data_in_code = parsed_obj.data_in_code
+            metadata["data_in_code"] = {
+                "data": str(data_in_code.data.hex()),
+                "data_size": str(data_in_code.data_size),
+                "size": str(data_in_code.size),
+            }
+    except (AttributeError, TypeError) as e:
+        LOG.debug(f"Caught {type(e)} while parsing {exe_file} Mach0 code signature.")
+    return metadata
 
 
 def parse_dex(dex_file):
@@ -1275,6 +1304,3 @@ def parse_dex(dex_file):
     except (AttributeError, TypeError) as e:
         LOG.exception(e)
     return cleanup_dict_lief_errors(metadata)
-
-
-

--- a/blint/binary.py
+++ b/blint/binary.py
@@ -1,9 +1,11 @@
+import contextlib
 import sys
 
 import lief
 
 from blint.logger import DEBUG, LOG
-from blint.utils import calculate_entropy, check_secret, decode_base64
+from blint.utils import calculate_entropy, check_secret, \
+    cleanup_dict_lief_errors, cleanup_list_lief_errors, decode_base64
 
 MIN_ENTROPY = 0.39
 MIN_LENGTH = 80
@@ -15,11 +17,16 @@ if LOG.level != DEBUG:
 ADDRESS_FMT = "0x{:<10x}"
 
 
-def parse_desc(e):
-    return "{:02x}".format(e)
-
-
 def is_shared_library(parsed_obj):
+    """
+    Checks if the given parsed binary object represents a shared library.
+
+    Args:
+        parsed_obj: The parsed binary object to be checked.
+
+    Returns:
+        bool: True if the parsed object represents a shared library.
+    """
     if not parsed_obj:
         return False
     if parsed_obj.format == lief.Binary.FORMATS.ELF:
@@ -34,90 +41,124 @@ def is_shared_library(parsed_obj):
 
 
 def parse_notes(parsed_obj):
-    metadata = {"notes": []}
+    """
+    Parses the notes from the given parsed binary object.
+
+    Args:
+        parsed_obj: The parsed binary object containing the notes.
+
+    Returns:
+        list[dict]: A list of metadata dictionaries, each representing a note.
+
+    Note:
+        - The description is truncated to 16 words and appended with "..." if 
+            it exceeds 16 words.
+    """
+    data = []
     notes = parsed_obj.notes
-    if len(notes):
-        for idx, note in enumerate(notes):
-            note_str = str(note)
-            build_id = ""
-            if "ID Hash" in note_str:
-                build_id = note_str.rsplit("ID Hash:", maxsplit=1)[-1].strip()
-            description = note.description
-            description_str = " ".join(map(parse_desc, description[:16]))
-            if len(description) > 16:
-                description_str += " ..."
-            type_str = note.type_core if note.is_core else note.type
-            type_str = str(type_str).rsplit(".", maxsplit=1)[-1]
-            note_details = note.details
-            note_details_str = ""
-            sdk_version = ""
-            ndk_version = ""
-            ndk_build_number = ""
-            abi = ""
-            version_str = ""
-            if isinstance(note_details, lief.ELF.AndroidIdent):
-                sdk_version = note_details.sdk_version
-                ndk_version = note_details.ndk_version
-                ndk_build_number = note_details.ndk_build_number
-            if isinstance(note_details, lief.ELF.NoteAbi):
-                version = note_details.version
-                abi = str(note_details.abi)
-                version_str = "{:d}.{:d}.{:d}".format(
-                    version[0], version[1], version[2]
-                )
-            if not version_str and type_str == "BUILD_ID" and build_id:
-                version_str = build_id
-            if note.is_core:
-                note_details_str = note.details
-            metadata["notes"].append(
-                {
-                    "index": idx,
-                    "description": description_str,
-                    "type": type_str,
-                    "details": note_details_str,
-                    "sdk_version": sdk_version,
-                    "ndk_version": ndk_version,
-                    "ndk_build_number": ndk_build_number,
-                    "abi": abi,
-                    "version": version_str,
-                    "build_id": build_id,
-                }
-            )
-    return metadata["notes"]
+    if not notes:
+        return data
+    data.extend(extract_note_data(idx, note) for idx, note in enumerate(notes))
+    return cleanup_list_lief_errors(data)
 
 
-def parse_uuid(e):
+def extract_note_data(idx, note):
+    """
+    Extracts metadata from a note object and returns a dictionary.
+
+    Args:
+        idx (int): The index of the note.
+        note: The note object to extract data from.
+    
+    Returns:
+        dict: A dictionary containing the extracted metadata
+    """
+    note_str = str(note)
+    build_id = ""
+    if "ID Hash" in note_str:
+        build_id = note_str.rsplit("ID Hash:", maxsplit=1)[-1].strip()
+    description = note.description
+    description_str = " ".join(map(integer_to_hex_str, description[:16]))
+    if len(description) > 16:
+        description_str += " ..."
+    type_str = note.type_core if note.is_core else note.type
+    type_str = str(type_str).rsplit(".", maxsplit=1)[-1]
+    note_details = note.details
+    note_details_str = ""
+    sdk_version = ""
+    ndk_version = ""
+    ndk_build_number = ""
+    abi = ""
+    version_str = ""
+    if isinstance(note_details, lief.ELF.AndroidIdent):
+        sdk_version = note_details.sdk_version
+        ndk_version = note_details.ndk_version
+        ndk_build_number = note_details.ndk_build_number
+    if isinstance(note_details, lief.ELF.NoteAbi):
+        version = note_details.version
+        abi = str(note_details.abi)
+        version_str = f"{version[0]}.{version[1]}.{version[2]}"
+    if not version_str and type_str == "BUILD_ID" and build_id:
+        version_str = build_id
+    if note.is_core:
+        note_details_str = note.details
+    return cleanup_dict_lief_errors({
+        "index": idx, "description": description_str, "type": type_str,
+        "details": note_details_str, "sdk_version": sdk_version,
+        "ndk_version": ndk_version, "ndk_build_number": ndk_build_number,
+        "abi": abi, "version": version_str, "build_id": build_id,
+    })
+
+
+def integer_to_hex_str(e):
+    """
+    Converts an integer to a hexadecimal string representation.
+
+    Args:
+        e: The integer to be converted.
+
+    Returns:
+        The hexadecimal string representation of the integer.
+    """
     return "{:02x}".format(e)
 
 
 def parse_relro(parsed_obj):
-    bind_now = False
-    now = False
-    try:
-        parsed_obj.get(lief.ELF.SEGMENT_TYPES.GNU_RELRO)
-    except lief.lief_errors.not_found:
+    """
+    Determines the Relocation Read-Only (RELRO) protection level.
+
+    Args:
+        parsed_obj: The parsed binary object to analyze.
+
+    Returns:
+        str: The RELRO protection level of the binary object.
+    """
+    test_stmt = parsed_obj.get(lief.ELF.SEGMENT_TYPES.GNU_RELRO)
+    if isinstance(test_stmt, lief.lief_errors):
         return "no"
-    try:
-        dynamic_tags = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.FLAGS)
-        if dynamic_tags:
-            bind_now = lief.ELF.DYNAMIC_FLAGS.BIND_NOW in dynamic_tags
-    except lief.lief_errors.not_found:
-        pass
-    try:
-        dynamic_tags = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.FLAGS_1)
-        if dynamic_tags:
-            now = lief.ELF.DYNAMIC_FLAGS_1.NOW in dynamic_tags
-    except lief.lief_errors.not_found:
-        pass
-    if bind_now or now:
-        return "full"
-    return "partial"
+    dynamic_tags = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.FLAGS)
+    bind_now, now = False, False
+    if dynamic_tags and not isinstance(dynamic_tags, lief.lief_errors):
+        bind_now = lief.ELF.DYNAMIC_FLAGS.BIND_NOW in dynamic_tags
+    dynamic_tags = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.FLAGS_1)
+    if dynamic_tags and not isinstance(dynamic_tags, lief.lief_errors):
+        now = lief.ELF.DYNAMIC_FLAGS_1.NOW in dynamic_tags
+    return "full" if bind_now or now else "partial"
 
 
 def parse_functions(functions):
-    try:
+    """
+    Parses a list of functions and returns a list of dictionaries.
+
+    Args:
+        functions (list): A list of function objects to parse.
+
+    Returns:
+        list[dict]: A list of function dictionaries
+    """
+    func_list = []
+    with contextlib.suppress(AttributeError, TypeError):
         LOG.debug("Parsing functions")
-        func_list = []
         for idx, f in enumerate(functions):
             if f.name and f.address:
                 cleaned_name = f.name.replace("..", "::")
@@ -128,56 +169,76 @@ def parse_functions(functions):
                         "address": ADDRESS_FMT.format(f.address),
                     }
                 )
-        return func_list
-    except Exception:
-        return []
+    return cleanup_list_lief_errors(func_list)
 
 
 def parse_strings(parsed_obj):
-    try:
+    """
+    Parse strings from a parsed object.
+
+    Args:
+        parsed_obj: The parsed object from which to extract strings.
+
+    Returns:
+        list: A list of dictionaries with keys: value, entropy, secret type
+    """
+    strings_list = []
+    with contextlib.suppress(AttributeError):
         LOG.debug("Parsing strings")
-        strings_list = []
         strings = parsed_obj.strings
+        if isinstance(strings, lief.lief_errors):
+            return strings_list
         for s in strings:
-            if s and "[]" not in s and "{}" not in s:
-                entropy = calculate_entropy(s)
-                secret_type = check_secret(s)
-                if (
-                    entropy and (entropy > MIN_ENTROPY or len(s) > MIN_LENGTH)
-                ) or secret_type:
-                    strings_list.append(
-                        {
-                            "value": (
-                                decode_base64(s) if s.endswith("==") else s
-                            ),
-                            "entropy": entropy,
-                            "secret_type": secret_type,
-                        }
-                    )
-        return strings_list
-    except Exception:
-        return []
+            try:
+                if s and "[]" not in s and "{}" not in s:
+                    entropy = calculate_entropy(s)
+                    secret_type = check_secret(s)
+                    if (
+                        entropy and
+                        (entropy > MIN_ENTROPY or len(s) > MIN_LENGTH)
+                    ) or secret_type:
+                        strings_list.append(
+                            {
+                                "value": (
+                                    decode_base64(s) if s.endswith("==") else s
+                                ),
+                                "entropy": entropy,
+                                "secret_type": secret_type,
+                            }
+                        )
+            except (AttributeError, TypeError):
+                continue
+    return cleanup_list_lief_errors(strings_list)
 
 
 def parse_symbols(symbols):
-    try:
-        LOG.debug("Parsing symbols")
-        symbols_list = []
-        exe_type = None
-        for symbol in symbols:
+    """
+    Parse symbols from a list of symbols.
+
+    Args:
+        symbols (it_symbols): A list of symbols to parse.
+
+    Returns:
+        tuple[list[dict], str]: A tuple containing the symbols_list and exe_type
+    """
+    symbols_list = []
+    exe_type = ""
+    LOG.debug("Parsing symbols")
+    for symbol in symbols:
+        try:
             symbol_version = symbol.symbol_version if symbol.has_version else ""
             is_imported = False
             is_exported = False
-            if symbol.imported:
+            if symbol.imported and not isinstance(
+                    symbol.imported, lief.lief_errors):
                 is_imported = True
-            if symbol.exported:
+            if symbol.exported and not isinstance(
+                    symbol.exported, lief.lief_errors):
                 is_exported = True
-            try:
-                symbol_name = symbol.demangled_name
-            except Exception:
+            symbol_name = symbol.demangled_name
+            if isinstance(symbol_name, lief.lief_errors):
                 symbol_name = symbol.name
-            if not exe_type:
-                exe_type = guess_exe_type(symbol_name)
+            exe_type = guess_exe_type(symbol_name)
             symbols_list.append(
                 {
                     "name": symbol_name,
@@ -196,19 +257,42 @@ def parse_symbols(symbols):
                     "version": str(symbol_version),
                 }
             )
-        return symbols_list, exe_type
-    except Exception:
-        return [], None
+        except (AttributeError, IndexError, TypeError):
+            continue
+    return cleanup_list_lief_errors(symbols_list), exe_type
 
 
 def parse_interpreter(parsed_obj):
+    """
+    Parses the interpreter information from the given parsed binary object.
+
+    Args:
+        parsed_obj: The parsed binary object to extract the interpreter from.
+
+    Returns:
+        str: The interpreter information of the binary object.
+    """
     try:
-        return parsed_obj.interpreter
-    except Exception:
+        interpreter =  parsed_obj.interpreter
+        if isinstance(interpreter, lief.lief_errors):
+            raise AttributeError
+        return interpreter
+    except AttributeError:
         return ""
 
 
 def detect_exe_type(parsed_obj, metadata):
+    """
+    Detects the type of the parsed binary object based on its characteristics 
+    and metadata.
+
+    Args:
+        parsed_obj: The parsed binary object to analyze.
+        metadata (dict): The metadata dictionary containing binary information .
+
+    Returns:
+        str: The detected type of the binary.
+    """
     try:
         if parsed_obj.has_section(".note.go.buildid"):
             return "gobinary"
@@ -219,18 +303,26 @@ def detect_exe_type(parsed_obj, metadata):
         ):
             return "genericbinary"
         if metadata.get("machine_type") and metadata.get("file_type"):
-            return "{}-{}".format(
-                metadata.get("machine_type"), metadata.get("file_type")
-            ).lower()
+            return (f'{metadata.get("machine_type")}-'
+                    f'{metadata.get("file_type")}').lower()
         if metadata["relro"] in ("partial", "full"):
             return "genericbinary"
-    except Exception:
+    except (AttributeError, TypeError):
         return ""
     return ""
 
 
 def guess_exe_type(symbol_name):
-    exe_type = None
+    """
+    Guess the executable type based on the symbol name.
+
+    Args:
+        symbol_name (str): The name of the symbol.
+
+    Returns:
+        str: The guessed executable type based on the symbol name.
+    """
+    exe_type = ""
     if "golang" in symbol_name or "_cgo_" in symbol_name:
         exe_type = "gobinary"
     if "_rust_" in symbol_name:
@@ -241,9 +333,18 @@ def guess_exe_type(symbol_name):
 
 
 def parse_pe_data(parsed_obj):
-    try:
+    """
+    Parses the data directories from the given parsed PE binary object.
+
+    Args:
+        parsed_obj: The parsed PE binary object to extract from.
+
+    Returns:
+        list[dict]: A list of dictionaries, each representing a data directory.
+    """
+    data_list = []
+    with contextlib.suppress(AttributeError, IndexError):
         LOG.debug("Parsing data dictionaries")
-        data_list = []
         data_directories = parsed_obj.data_directories
         for directory in data_directories:
             section_name = ""
@@ -256,7 +357,8 @@ def parse_pe_data(parsed_obj):
                         section_chars = ", ".join(
                             [
                                 str(chara).rsplit(".", maxsplit=1)[-1]
-                                for chara in directory.section.characteristics_lists
+                                for chara
+                                in directory.section.characteristics_lists
                             ]
                         )
                     section_name = directory.section.name
@@ -271,40 +373,52 @@ def parse_pe_data(parsed_obj):
                         "section_entropy": section_entropy,
                     }
                 )
-        return data_list
-    except Exception:
-        return None
+    return cleanup_list_lief_errors(data_list)
 
 
 def process_pe_resources(parsed_obj):
+    """
+    Processes the resources of the parsed PE (Portable Executable) binary object
+    and returns metadata about the resources.
+
+    Args:
+        parsed_obj: The parsed PE binary object to process the resources from.
+
+    Returns:
+        dict: A dictionary containing metadata about the resources
+    """
     try:
         LOG.debug("Parsing PE resources")
         rm = parsed_obj.resources_manager
-        metadata = {
-            "has_accelerator": rm.has_accelerator,
-            "has_dialogs": rm.has_dialogs,
-            "has_html": rm.has_html,
-            "has_icons": rm.has_icons,
+        return cleanup_dict_lief_errors({
+            "has_accelerator": rm.has_accelerator, "has_dialogs": rm.has_dialogs,
+            "has_html": rm.has_html, "has_icons": rm.has_icons,
             "has_manifest": rm.has_manifest,
             "has_string_table": rm.has_string_table,
             "has_version": rm.has_version,
-            "html": rm.html if rm.has_html else None,
-            "manifest": (
-                rm.manifest.replace("\\xef\\xbb\\xbf", "")
-                if rm.has_manifest
-                else None
-            ),
+            "html": rm.html if rm.has_html else None, "manifest": (
+            rm.manifest.replace("\\xef\\xbb\\xbf",
+                                "") if rm.has_manifest else None),
             "version_info": str(rm.version) if rm.has_version else None,
-        }
-        return metadata
-    except Exception:
-        return None
+        })
+    except AttributeError:
+        return {}
 
 
 def process_pe_signature(parsed_obj):
-    try:
-        signature_list = []
-        for _, sig in enumerate(parsed_obj.signatures):
+    """
+    Processes the signatures of the parsed PE (Portable Executable) binary 
+    object and returns information about the signatures.
+
+    Args:
+        parsed_obj: The parsed PE binary object to process the signatures from.
+    
+    Returns:
+        list[dict]: A list of dictionaries containing signatures info. 
+    """
+    signature_list = []
+    with contextlib.suppress(AttributeError, TypeError, KeyError):
+        for sig in parsed_obj.signatures:
             ci = sig.content_info
             signature_obj = {
                 "version": sig.version,
@@ -328,12 +442,19 @@ def process_pe_signature(parsed_obj):
                 signers_list.append(signer_obj)
             signature_obj["signers"] = signers_list
             signature_list.append(signature_obj)
-        return signature_list
-    except Exception:
-        return None
+    return cleanup_list_lief_errors(signature_list)
 
 
 def parse_pe_authenticode(parsed_obj):
+    """
+    Parses the Authenticode information from the given parsed PE.
+
+    Args:
+        parsed_obj: The parsed PE binary object to extract.
+
+    Returns:
+        dict: A dictionary containing the Authenticode information
+    """
     try:
         LOG.debug("Parsing authentihash")
         authenticode = {}
@@ -362,17 +483,28 @@ def parse_pe_authenticode(parsed_obj):
                         tmp_key = "version"
                     cert_signer_obj[tmp_key] = tmp_a[1].strip()
             authenticode["cert_signer"] = cert_signer_obj
-        return authenticode
-    except Exception:
-        return None
+        return cleanup_dict_lief_errors(authenticode)
+    except (AttributeError, IndexError, KeyError, TypeError):
+        return {}
 
 
 def parse_pe_symbols(symbols):
-    try:
-        LOG.debug("Parsing symbols")
-        symbols_list = []
-        exe_type = None
-        for symbol in symbols:
+    """
+    Parses the symbols and determines the executable type.
+
+    Args:
+        symbols (list): A list of symbol objects to parse.
+
+    Returns:
+        tuple: A tuple containing two elements:
+            - symbols_list (list): A list of symbol dictionaries
+            - exe_type (str): The determined executable type.
+    """
+    LOG.debug("Parsing symbols")
+    symbols_list = []
+    exe_type = ""
+    for symbol in symbols:
+        try:
             if symbol.section_number <= 0:
                 section_nb_str = str(
                     lief.PE.SYMBOL_SECTION_NUMBER(symbol.section_number)
@@ -380,69 +512,91 @@ def parse_pe_symbols(symbols):
             else:
                 try:
                     section_nb_str = symbol.section.name
-                except Exception:
+                except AttributeError:
                     section_nb_str = "section<{:d}>".format(
                         symbol.section_number
                     )
-            try:
-                if not exe_type:
-                    try:
-                        exe_type = guess_exe_type(symbol.name.lower())
-                    except Exception:
-                        pass
-                if symbol.name:
-                    symbols_list.append(
-                        {
-                            "name": symbol.name.replace("..", "::"),
-                            "value": symbol.value,
-                            "id": section_nb_str,
-                            "base_type": str(symbol.base_type).rsplit(
-                                ".", maxsplit=1
-                            )[-1],
-                            "complex_type": str(symbol.complex_type).rsplit(
-                                ".", maxsplit=1
-                            )[-1],
-                            "storage_class": str(symbol.storage_class).rsplit(
-                                ".", maxsplit=1
-                            )[-1],
-                        }
-                    )
-            except Exception:
-                pass
-        return symbols_list, exe_type
-    except Exception:
-        return [], None
+        except (AttributeError, TypeError):
+            section_nb_str = ""
+        with contextlib.suppress(IndexError, AttributeError, ValueError):
+            if not exe_type:
+                try:
+                    exe_type = guess_exe_type(symbol.name.lower())
+                except AttributeError:
+                    exe_type = ""
+            if symbol.name:
+                symbols_list.append(
+                    {
+                        "name": symbol.name.replace("..", "::"),
+                        "value": symbol.value,
+                        "id": section_nb_str,
+                        "base_type": str(symbol.base_type).rsplit(
+                            ".", maxsplit=1
+                        )[-1],
+                        "complex_type": str(symbol.complex_type).rsplit(
+                            ".", maxsplit=1
+                        )[-1],
+                        "storage_class": str(symbol.storage_class).rsplit(
+                            ".", maxsplit=1
+                        )[-1],
+                    }
+                )
+    return cleanup_list_lief_errors(symbols_list), exe_type
 
 
 def parse_pe_imports(imports):
-    try:
-        LOG.debug("Parsing imports")
-        imports_list = []
-        dlls = set()
-        for import_ in imports:
+    """
+    Parses the imports and returns lists of imported symbols and DLLs.
+
+    Args:
+        imports (it_imports): A list of import objects to parse.
+
+    Returns:
+        tuple: A tuple containing two elements:
+            - imports_list (list[dict])
+            - dll_list (list[dict])
+    """
+    LOG.debug("Parsing imports")
+    imports_list = []
+    dlls = set()
+    for import_ in imports:
+        try:
             entries = import_.entries
-            for entry in entries:
+        except AttributeError:
+            break
+        for entry in entries:
+            try:
                 if entry.name:
                     dlls.add(import_.name)
                     imports_list.append(
                         {
-                            "name": "{}::{}".format(import_.name, entry.name),
+                            "name": f"{import_.name}::{entry.name}",
                             "short_name": entry.name,
                             "data": entry.data,
                             "iat_value": entry.iat_value,
                             "hint": entry.hint,
                         }
                     )
-        dll_list = [{"name": d, "tag": "NEEDED"} for d in list(dlls)]
-        return imports_list, dll_list
-    except Exception:
-        return []
+            except AttributeError:
+                continue
+    dll_list = [{"name": d, "tag": "NEEDED"} for d in list(dlls)]
+    return cleanup_list_lief_errors(imports_list), cleanup_list_lief_errors(dll_list)
 
 
 def parse_pe_exports(exports):
-    try:
+    """
+    Parses the exports and returns a list of exported symbols.
+
+    Args:
+        exports: The exports object to parse.
+
+    Returns:
+        list[dict]: A list of exported symbol dictionaries.
+
+    """
+    exports_list = []
+    with contextlib.suppress(AttributeError):
         LOG.debug("Parsing exports")
-        exports_list = []
         entries = exports.entries
         metadata = {}
         for entry in entries:
@@ -460,19 +614,28 @@ def parse_pe_exports(exports):
                 metadata["fwd_library"] = fwd.library
                 metadata["fwd_function"] = fwd.function
             exports_list.append(metadata)
-        return exports_list
-    except Exception:
-        return []
+    return cleanup_list_lief_errors(exports_list)
 
 
 def parse_macho_symbols(symbols):
-    try:
-        LOG.debug("Parsing symbols")
-        symbols_list = []
-        exe_type = None
-        if len(symbols) == 0:
-            return [], None
-        for symbol in symbols:
+    """
+    Parses the symbols and determines the executable type.
+
+    Args:
+        symbols (it_symbols): A list of symbol objects to parse.
+
+    Returns:
+        tuple: A tuple containing two elements:
+            - symbols_list (list): A list of symbol dictionaries.
+            - exe_type (str): The determined executable type.
+    """
+    LOG.debug("Parsing symbols")
+    symbols_list = []
+    exe_type = ""
+    if not symbols:
+        return symbols_list, exe_type
+    for symbol in symbols:
+        try:
             libname = ""
             if symbol.has_binding_info and symbol.binding_info.has_library:
                 libname = symbol.binding_info.library.name
@@ -485,7 +648,7 @@ def parse_macho_symbols(symbols):
 
             try:
                 symbol_name = symbol.demangled_name
-            except Exception:
+            except AttributeError:
                 symbol_name = symbol.name
             symbol_name = symbol_name.replace("..", "::")
             if not exe_type:
@@ -493,7 +656,7 @@ def parse_macho_symbols(symbols):
             symbols_list.append(
                 {
                     "name": (
-                        "{}::{}".format(libname, symbol_name)
+                        f"{libname}::{symbol_name}"
                         if libname
                         else symbol_name
                     ),
@@ -504,12 +667,12 @@ def parse_macho_symbols(symbols):
                     "value": symbol_value,
                 }
             )
-        return symbols_list, exe_type
-    except Exception:
-        return [], None
+        except (AttributeError, TypeError):
+            continue
+    return cleanup_list_lief_errors(symbols_list), exe_type
 
 
-def parse(exe_file):
+def parse(exe_file):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     """
     Parse the executable using lief and capture the metadata
 
@@ -594,29 +757,33 @@ def parse(exe_file):
             # Canary check
             canary_sections = ["__stack_chk_fail", "__intel_security_cookie"]
             for section in canary_sections:
-                try:
-                    if parsed_obj.get_symbol(section):
+                if parsed_obj.get_symbol(section):
+                    if isinstance(
+                            parsed_obj.get_symbol(section), lief.lief_errors):
+                        metadata["has_canary"] = False
+                    else:
                         metadata["has_canary"] = True
                         break
-                except lief.lief_errors.not_found:
-                    metadata["has_canary"] = False
             # rpath check
-            try:
-                if parsed_obj.get(lief.ELF.DYNAMIC_TAGS.RPATH):
-                    metadata["has_rpath"] = True
-            except lief.lief_errors.not_found:
+            rpath = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.RPATH)
+            if isinstance(rpath, lief.lief_errors):
                 metadata["has_rpath"] = False
+            elif rpath:
+                metadata["has_rpath"] = True
             # runpath check
-            try:
-                if parsed_obj.get(lief.ELF.DYNAMIC_TAGS.RUNPATH):
-                    metadata["has_runpath"] = True
-            except lief.lief_errors.not_found:
+            runpath = parsed_obj.get(lief.ELF.DYNAMIC_TAGS.RUNPATH)
+            if isinstance(runpath, lief.lief_errors):
                 metadata["has_runpath"] = False
+            elif runpath:
+                metadata["has_runpath"] = True
             static_symbols = parsed_obj.static_symbols
-            if len(static_symbols):
+            if static_symbols and not isinstance(
+                    static_symbols, lief.lief_errors):
                 metadata["static"] = True
             dynamic_entries = parsed_obj.dynamic_entries
-            if len(dynamic_entries):
+            if dynamic_entries and not isinstance(
+                dynamic_entries, lief.lief_errors
+            ):
                 metadata["dynamic_entries"] = []
                 for entry in dynamic_entries:
                     if entry.tag == lief.ELF.DYNAMIC_TAGS.NULL:
@@ -664,13 +831,13 @@ def parse(exe_file):
                                     "value": entry.value,
                                 }
                             )
-            except Exception:
+            except (AttributeError, TypeError):
                 metadata["symbols_version"] = []
             try:
                 notes = parsed_obj.notes
                 if notes:
                     metadata["notes"] = parse_notes(parsed_obj)
-            except Exception:
+            except (AttributeError, TypeError):
                 pass
             metadata["strings"] = parse_strings(parsed_obj)
             try:
@@ -679,7 +846,7 @@ def parse(exe_file):
                 )
                 if exe_type:
                     metadata["exe_type"] = exe_type
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 metadata["dynamic_symbols"], exe_type = parse_symbols(
@@ -687,17 +854,17 @@ def parse(exe_file):
                 )
                 if exe_type:
                     metadata["exe_type"] = exe_type
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 metadata["functions"] = parse_functions(parsed_obj.functions)
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 metadata["ctor_functions"] = parse_functions(
                     parsed_obj.ctor_functions
                 )
-            except Exception:
+            except AttributeError:
                 pass
         elif isinstance(parsed_obj, lief.PE.Binary):
             # PE
@@ -834,56 +1001,45 @@ def parse(exe_file):
                 )
             except Exception:
                 pass
-            try:
                 metadata["data_directories"] = parse_pe_data(parsed_obj)
-            except Exception:
-                pass
-            try:
                 metadata["authenticode"] = parse_pe_authenticode(parsed_obj)
-            except Exception:
-                pass
-            try:
                 metadata["signatures"] = process_pe_signature(parsed_obj)
-            except Exception:
-                pass
-            try:
                 metadata["resources"] = process_pe_resources(parsed_obj)
-            except Exception:
-                pass
+
             try:
                 metadata["static_symbols"], exe_type = parse_pe_symbols(
                     parsed_obj.symbols
                 )
                 if exe_type:
                     metadata["exe_type"] = exe_type
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 (
                     metadata["imports"],
                     metadata["dynamic_entries"],
                 ) = parse_pe_imports(parsed_obj.imports)
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 metadata["exports"] = parse_pe_exports(parsed_obj.get_export())
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 metadata["functions"] = parse_functions(parsed_obj.functions)
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 metadata["ctor_functions"] = parse_functions(
                     parsed_obj.ctor_functions
                 )
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 metadata["exception_functions"] = parse_functions(
                     parsed_obj.exception_functions
                 )
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 tls = parsed_obj.tls
@@ -894,7 +1050,7 @@ def parse(exe_file):
                     metadata["tls_characteristics"] = tls.characteristics
                     metadata["tls_section_name"] = tls.section.name
                     metadata["tls_directory_type"] = str(tls.directory.type)
-            except Exception:
+            except (AttributeError, TypeError):
                 pass
         elif isinstance(parsed_obj, lief.MachO.Binary):
             # MachO
@@ -984,7 +1140,7 @@ def parse(exe_file):
             try:
                 cmd = parsed_obj.uuid
                 if cmd:
-                    uuid_str = " ".join(map(parse_uuid, cmd.uuid))
+                    uuid_str = " ".join(map(integer_to_hex_str, cmd.uuid))
                     metadata["uuid"] = str(uuid_str)
             except Exception:
                 pass
@@ -995,7 +1151,7 @@ def parse(exe_file):
                         current_version_str = "{:d}.{:d}.{:d}".format(
                             *library.current_version
                         )
-                        compatibility_version_str = "{:d}.{:d}.{:d}".format(
+                        compat_version_str = "{:d}.{:d}.{:d}".format(
                             *library.compatibility_version
                         )
                         metadata["libraries"].append(
@@ -1003,7 +1159,7 @@ def parse(exe_file):
                                 "name": library.name,
                                 "timestamp": library.timestamp,
                                 "version": current_version_str,
-                                "compatibility_version": compatibility_version_str,
+                                "compatibility_version": compat_version_str,
                             }
                         )
             except Exception:
@@ -1034,42 +1190,36 @@ def parse(exe_file):
                 pass
             try:
                 if parsed_obj.main_command:
-                    metadata["has_main_command"] = True
+                    metadata["has_main_command"] = (
+                        False if isinstance(
+                            parsed_obj.main_command, lief.lief_errors)
+                        else True
+                    )
                 if parsed_obj.thread_command:
-                    metadata["has_thread_command"] = True
-            except lief.lief_errors.not_found:
+                    metadata["has_thread_command"] = (
+                        False if isinstance(
+                            parsed_obj.thread_command, lief.lief_errors)
+                        else True
+                    )
+            except AttributeError:
                 metadata["has_main"] = False
                 metadata["has_thread_command"] = False
-            try:
+            with contextlib.suppress(AttributeError):
                 metadata["functions"] = parse_functions(parsed_obj.functions)
-            except Exception:
-                pass
-            try:
                 metadata["ctor_functions"] = parse_functions(
                     parsed_obj.ctor_functions
                 )
-            except Exception:
-                pass
-            try:
                 metadata["unwind_functions"] = parse_functions(
                     parsed_obj.unwind_functions
                 )
-            except Exception:
-                pass
-            try:
                 metadata["static_symbols"], exe_type = parse_macho_symbols(
                     parsed_obj.symbols
                 )
                 if exe_type:
                     metadata["exe_type"] = exe_type
-            except Exception:
-                pass
-            try:
                 if parsed_obj.dylinker:
                     metadata["dylinker"] = parsed_obj.dylinker.name
-            except Exception:
-                pass
-            try:
+            with contextlib.suppress(AttributeError, TypeError):
                 if parsed_obj.has_code_signature:
                     code_signature = parsed_obj.code_signature
                     metadata["code_signature"] = {
@@ -1101,11 +1251,9 @@ def parse(exe_file):
                         "data_size": str(data_in_code.data_size),
                         "size": str(data_in_code.size),
                     }
-            except Exception:
-                pass
-    except Exception as e:
+    except (AttributeError, TypeError, ValueError) as e:
         LOG.exception(e)
-    return metadata
+    return cleanup_dict_lief_errors(metadata)
 
 
 def parse_dex(dex_file):
@@ -1113,6 +1261,8 @@ def parse_dex(dex_file):
     metadata = {"file_path": dex_file}
     try:
         dexfile_obj = lief.DEX.parse(dex_file)
+        if isinstance(dexfile_obj, lief.lief_errors):
+            return metadata
         metadata["version"] = dexfile_obj.version
         metadata["header"] = dexfile_obj.header
         metadata["classes"] = list(dexfile_obj.classes)
@@ -1122,6 +1272,9 @@ def parse_dex(dex_file):
         metadata["types"] = list(dexfile_obj.types)
         metadata["prototypes"] = list(dexfile_obj.prototypes)
         metadata["map"] = dexfile_obj.map
-    except Exception as e:
+    except (AttributeError, TypeError) as e:
         LOG.exception(e)
-    return metadata
+    return cleanup_dict_lief_errors(metadata)
+
+
+

--- a/blint/checks.py
+++ b/blint/checks.py
@@ -1,0 +1,82 @@
+from blint.utils import parse_pe_manifest
+
+
+def check_nx(f, metadata, rule_obj):  # noqa
+    return metadata.get("has_nx") is not False
+
+
+def check_pie(f, metadata, rule_obj):  # noqa
+    return metadata.get("is_pie") is not False
+
+
+def check_relro(f, metadata, rule_obj): # noqa
+    return metadata.get("relro") != "no"
+
+
+def check_canary(f, metadata, rule_obj): # noqa
+    return metadata.get("has_canary") is not False
+
+
+def check_rpath(f, metadata, rule_obj): # noqa
+    # Do not recommend setting rpath or runpath
+    return not metadata.get("has_rpath") and not metadata.get("has_runpath")
+
+
+def check_virtual_size(f, metadata, rule_obj): # noqa
+    if metadata.get("virtual_size"):
+        virtual_size = metadata.get("virtual_size") / 1024 / 1024
+        size_limit = 30
+        if rule_obj.get("limit"):
+            limit = rule_obj.get("limit")
+            limit = limit.replace("MB", "").replace("M", "")
+            if isinstance(limit, str) and rule_obj.get("limit").isdigit():
+                size_limit = int(rule_obj.get("limit"))
+        return virtual_size < size_limit
+    return True
+
+
+def check_authenticode(f, metadata, rule_obj): # noqa
+    if metadata.get("authenticode"):
+        authenticode_obj = metadata.get("authenticode")
+        vf = authenticode_obj.get("verification_flags", "").lower()
+        return False if vf != "ok" else bool(
+            authenticode_obj.get("cert_signer"))
+    return True
+
+
+def check_dll_characteristics(f, metadata, rule_obj):  # noqa
+    res = []
+    if metadata.get("dll_characteristics"):
+        res.extend(
+            c
+            for c in rule_obj.get("mandatory_values", [])
+            if c not in metadata.get("dll_characteristics")
+        )
+    if res:
+        res = ", ".join(res)
+
+    return res or True
+
+
+def check_codesign(f, metadata, rule_obj): # noqa
+    if metadata.get("code_signature"):
+        code_signature = metadata.get("code_signature")
+        return (not code_signature or
+                code_signature.get("available") is not False)
+    return True
+
+
+def check_trust_info(f, metadata, rule_obj): # noqa
+    if metadata.get("resources"):
+        if manifest := metadata.get("resources").get("manifest"):
+            attribs_dict = parse_pe_manifest(manifest)
+            if not attribs_dict:
+                return True
+            allowed_values = rule_obj.get("allowed_values", {})
+            for k, v in allowed_values.items():
+                manifest_k = attribs_dict.get(k)
+                if isinstance(v, dict) and isinstance(manifest_k, dict):
+                    for vk, vv in v.items():
+                        if str(manifest_k.get(vk)).lower() != str(vv).lower():
+                            return f"{vk}:{manifest_k.get(vk)}"
+    return True

--- a/blint/checks.py
+++ b/blint/checks.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring,unused-argument
 from blint.utils import parse_pe_manifest
 
 
@@ -61,8 +62,7 @@ def check_dll_characteristics(f, metadata, rule_obj):  # noqa
 def check_codesign(f, metadata, rule_obj): # noqa
     if metadata.get("code_signature"):
         code_signature = metadata.get("code_signature")
-        return (not code_signature or
-                code_signature.get("available") is not False)
+        return not code_signature or code_signature.get("available") is not False
     return True
 
 

--- a/blint/cli.py
+++ b/blint/cli.py
@@ -5,10 +5,12 @@ import argparse
 import os
 import sys
 
-from blint.analysis import report, start
 from blint.sbom import generate
+from blint.logger import LOG
+from blint.analysis import AnalysisRunner, report
+from blint.utils import gen_file_list
 
-blint_logo = """
+BLINT_LOGO = """
 ██████╗ ██╗     ██╗███╗   ██╗████████╗
 ██╔══██╗██║     ██║████╗  ██║╚══██╔══╝
 ██████╔╝██║     ██║██╔██╗ ██║   ██║
@@ -32,12 +34,14 @@ def build_args():
         dest="src_dir_image",
         action="extend",
         nargs="+",
-        help="Source directories, container images or binary files. Defaults to current directory.",
+        help="Source directories, container images or binary files. Defaults "
+             "to current directory.",
     )
     parser.add_argument(
         "-o",
         "--reports",
         dest="reports_dir",
+        default=os.path.join(os.getcwd(), "reports"),
         help="Reports directory. Defaults to reports.",
     )
     parser.add_argument(
@@ -83,7 +87,8 @@ def build_args():
         dest="src_dir_image",
         action="extend",
         nargs="+",
-        help="Source directories, container images or binary files. Defaults to current directory.",
+        help="Source directories, container images or binary files. Defaults "
+             "to current directory.",
     )
     sbom_parser.add_argument(
         "-o",
@@ -96,36 +101,67 @@ def build_args():
         action="store_true",
         default=False,
         dest="deep_mode",
-        help="Enable deep mode to collect more used symbols and modules aggressively. Slow operation.",
+        help="Enable deep mode to collect more used symbols and modules "
+             "aggressively. Slow operation.",
     )
     return parser.parse_args()
 
 
 def parse_input(src):
+    """Parses the input source.
+
+    This function takes the input source as a list and parses it to extract the
+    path. It returns the parsed path as a list.
+
+    Args:
+        src: A list containing the input source.
+
+    Returns:
+        list: A list containing the parsed path.
+    """
     path = src[0]
     result = path.split("\n")
     result.pop()
     return result
 
 
-def main():
+def handle_args():
+    """Handles the command-line arguments.
+
+    This function parses the command-line arguments and returns the parsed
+    arguments, reports directory, and source directory.
+
+    Returns:
+        tuple: A tuple containing the parsed arguments, reports directory, and
+               source directory.
+    """
     args = build_args()
     if not args.no_banner:
-        print(blint_logo)
+        print(BLINT_LOGO)
+    if not args.src_dir_image:
+        args.src_dir_image = [os.getcwd()]
     if not os.getenv("CI"):
         src_dirs = args.src_dir_image
     else:
         src_dirs = parse_input(args.src_dir_image)
-    if not src_dirs:
-        src_dirs = [os.getcwd()]
-    if args.reports_dir:
-        reports_dir = args.reports_dir
-    else:
-        reports_dir = os.path.join(os.getcwd(), "reports")
+
+    # Create reports directory
+    reports_dir = args.reports_dir
+
+    if not os.path.exists(reports_dir):
+        os.makedirs(reports_dir)
+
     for src in src_dirs:
         if not os.path.exists(src):
-            print(f"{src} is an invalid file or directory!")
-            return
+            LOG.error(f"{src} is an invalid file or directory!")
+            sys.exit(1)
+    return args, reports_dir, src_dirs
+
+
+def main():
+    """Main function of the blint tool"""
+    args, reports_dir, src_dirs = handle_args()
+
     # SBOM command
     if args.subcommand_name == "sbom":
         if args.sbom_output:
@@ -135,14 +171,14 @@ def main():
         generate(src_dirs, sbom_output, args.deep_mode)
     # Default case
     else:
-        # Create reports directory
-        if reports_dir and not os.path.exists(reports_dir):
-            os.makedirs(reports_dir)
-        findings, reviews, files, fuzzables = start(args, src_dirs, reports_dir)
-        report(args, src_dirs, reports_dir, findings, reviews, files, fuzzables)
+        files = gen_file_list(src_dirs)
+        analyzer = AnalysisRunner()
+        findings, reviews, fuzzables = analyzer.start(args, files, reports_dir)
+        report(src_dirs, reports_dir, findings, reviews, files, fuzzables)
+
         if os.getenv("CI") and not args.noerror:
             for f in findings:
-                if f["severity"] == "critical":
+                if f['severity'] == 'critical':
                     sys.exit(1)
 
 

--- a/blint/cyclonedx/spdx.py
+++ b/blint/cyclonedx/spdx.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 
 
-class Schema(Enum): # noqa
+class Schema(Enum):
     field_0BSD = "0BSD"
     AAL = "AAL"
     Abstyles = "Abstyles"

--- a/blint/cyclonedx/spdx.py
+++ b/blint/cyclonedx/spdx.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 
 
-class Schema(Enum):
+class Schema(Enum): # noqa
     field_0BSD = "0BSD"
     AAL = "AAL"
     Abstyles = "Abstyles"

--- a/blint/sbom.py
+++ b/blint/sbom.py
@@ -242,10 +242,7 @@ def trim_components(components):
         list: A list of unique components after trimming duplicates.
     """
     added_dict = {}
-    ret = []
     for comp in components:
         if not added_dict.get(comp.bom_ref.model_dump(mode="python")):
             added_dict[comp.bom_ref.model_dump(mode="python")] = comp
-    for k in sorted(added_dict.keys()):
-        ret.append(added_dict[k])
-    return ret
+    return [added_dict[k] for k in sorted(added_dict.keys())]

--- a/blint/utils.py
+++ b/blint/utils.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import math
 import os
 import re
@@ -9,8 +10,12 @@ from importlib.metadata import distribution
 from pathlib import Path
 
 from defusedxml.ElementTree import fromstring
+from lief import lief_errors
+from rich import box
+from rich.table import Table
+from blint.logger import console
 
-charset = string.digits + string.ascii_letters + r"""!&@"""
+CHARSET = string.digits + string.ascii_letters + r"""!&@"""
 
 # Default ignore list
 ignore_directories = [
@@ -84,7 +89,7 @@ ignore_files = [
     ".nupkg",
 ]
 
-strings_allowlist = [
+strings_allowlist = {
     "()",
     "[]",
     "{}",
@@ -118,7 +123,6 @@ strings_allowlist = [
     "*dsa",
     "*log",
     "*sql",
-    "*zip",
     "*json",
     "*yaml",
     "*xz",
@@ -145,1052 +149,162 @@ strings_allowlist = [
     "ECDHE-ECDSA-AES256-GCM",
     "setsockopt",
     ".jar",
-]
+}
 
 # Method names containing common verbs that could be fuzzed
 fuzzable_names = [
-    "create",
-    "delete",
-    "update",
-    "insert",
-    "upsert",
-    "post",
-    "put",
-    "get",
-    "index",
-    "encrypt",
-    "decrypt",
-    "load",
-    "import",
-    "export",
-    "encode",
-    "decode",
-    "obfuscate",
-    "store",
-    "fuzz",
-    "route",
-    "search",
-    "find",
-    "open",
-    "send",
-    "receive",
-    "approve",
-    "reject",
-    "password",
-    "lock",
-    "find",
-    "allocate",
-    "peer",
-    "block",
-    "socket",
-    "database",
-    "remote",
-    "api",
-    "build",
-    "transact",
-    "engage",
-    "quote",
-    "unicode",
-    "escape",
-    "invoke",
-    "execute",
-    "process",
-    "shell",
-    "env",
-    "valid",
-    "saniti",
-    "check",
-    "audit",
-    "follow",
+    "create", "delete", "update", "insert", "upsert", "post",
+    "put", "get", "index", "encrypt", "decrypt", "load", "import", "export",
+    "encode", "decode", "obfuscate", "store", "fuzz", "route", "search", "find",
+    "open", "send", "receive", "approve", "reject", "password", "lock", "find",
+    "allocate", "peer", "block", "socket", "database", "remote", "api", "build",
+    "transact", "engage", "quote", "unicode", "escape", "invoke", "execute",
+    "process", "shell", "env", "valid", "saniti", "check", "audit", "follow",
     "link",
 ]
-
-# import nltk
-# nltk.download('treebank')
-# nltk.download('universal_tagset')
-# wsj = nltk.corpus.treebank.tagged_words(tagset='universal')
-# word_tag_fd = nltk.FreqDist(wsj)
-# [wt[0] for (wt, _) in word_tag_fd.most_common() if wt[1] == 'VERB' and len(wt[0]) > 4 and not wt[0].endswith("en") and not wt[0].endswith("ing") and (wt[0].endswith("e") or wt[0].endswith("ed"))]
 fuzzable_names += [
-    "expect",
-    "add",
-    "report",
-    "compare",
-    "base",
-    "close",
-    "offer",
-    "price",
-    "approve",
-    "increase",
-    "become",
-    "propose",
-    "decline",
-    "raise",
-    "estimate",
-    "call",
-    "design",
-    "acquire",
-    "gain",
-    "reach",
-    "announce",
-    "fill",
-    "became",
-    "include",
-    "decid",
-    "disclose",
-    "agree",
-    "fail",
-    "complete",
-    "raise",
-    "trade",
-    "continue",
-    "include",
-    "believe",
-    "receive",
-    "schedule",
-    "indicate",
-    "provide",
-    "help",
-    "need",
-    "cause",
-    "drop",
-    "show",
-    "order",
-    "chang",
-    "launch",
-    "reduce",
-    "plan",
-    "want",
-    "follow",
-    "trade",
-    "improve",
-    "issu",
-    "involve",
-    "reject",
-    "increase",
-    "turn",
-    "barr",
-    "earn",
-    "consent",
-    "total",
-    "acquire",
-    "require",
-    "prefer",
-    "produce",
-    "introduce",
-    "consider",
-    "suspend",
-    "prove",
-    "open",
-    "close",
-    "boost",
-    "list",
-    "prepare",
-    "allow",
-    "approve",
-    "wrote",
-    "reduce",
-    "advance",
-    "describe",
-    "produce",
-    "operate",
-    "surge",
-    "jump",
-    "provide",
-    "mature",
-    "stop",
-    "work",
-    "introduce",
-    "relate",
-    "improve",
-    "seem",
-    "force",
-    "leave",
-    "believe",
-    "develop",
-    "decline",
-    "expire",
-    "invest",
-    "settle",
-    "change",
-    "contribute",
-    "elaborate",
-    "refuse",
-    "quote",
-    "pass",
-    "threaten",
-    "cause",
-    "violate",
-    "soar",
-    "eliminate",
-    "create",
-    "replace",
-    "argue",
-    "elect",
-    "complete",
-    "issue",
-    "register",
-    "pursue",
-    "combine",
-    "start",
-    "cover",
-    "eliminate",
-    "plunge",
-    "contain",
-    "manag",
-    "suggest",
-    "appear",
-    "discover",
-    "oppose",
-    "form",
-    "limit",
-    "force",
-    "disgorge",
-    "attribut",
-    "studi",
-    "resign",
-    "settl",
-    "retire",
-    "move",
-    "anticipat",
-    "decide",
-    "prompt",
-    "maintain",
-    "rang",
-    "focus",
-    "climb",
-    "adjust",
-    "award",
-    "carri",
-    "identif",
-    "confirm",
-    "match",
-    "conclude",
-    "sign",
-    "adopt",
-    "accept",
-    "expand",
-    "exercise",
-    "finish",
-    "finance",
-    "charge",
-    "realize",
-    "remain",
-    "express",
-    "replace",
-    "deliver",
-    "dump",
-    "import",
-    "assume",
-    "capture",
-    "join",
-    "releas",
-    "lower",
-    "exce",
-    "determin",
-    "locat",
-    "appli",
-    "complain",
-    "trigger",
-    "enter",
-    "intend",
-    "purchas",
-    "blam",
-    "learn",
-    "renew",
-    "view",
-    "speculat",
-    "choose",
-    "respond",
-    "encourage",
-    "dismiss",
-    "realiz",
-    "serve",
-    "associat",
-    "slipp",
-    "spark",
-    "negotiate",
-    "pleas",
-    "divid",
-    "financ",
-    "execute",
-    "discuss",
-    "hir",
-    "reflect",
-    "determine",
-    "market",
-    "warn",
-    "qualifi",
-    "explain",
-    "impose",
-    "recognize",
-    "indicate",
-    "point",
-    "collect",
-    "benefit",
-    "attach",
-    "compete",
-    "incurr",
-    "remove",
-    "share",
-    "request",
-    "permit",
-    "remove",
-    "revive",
-    "predict",
-    "couple",
-    "play",
-    "commit",
-    "revive",
-    "kill",
-    "present",
-    "deserve",
-    "convict",
-    "agree",
-    "accommodate",
-    "surrender",
-    "restore",
-    "restructur",
-    "fear",
-    "represent",
-    "fund",
-    "involve",
-    "redeem",
-    "resolve",
-    "obtain",
-    "employ",
-    "promote",
-    "impose",
-    "insist",
-    "contact",
-    "print",
-    "advertise",
-    "damage",
-    "exercis",
-    "auction",
-    "disappoint",
-    "subordinat",
-    "secure",
-    "integrat",
-    "perform",
-    "stepp",
-    "regulat",
-    "trail",
-    "occurr",
-    "expell",
-    "amount",
-    "back",
-    "regard",
-    "conclude",
-    "dominat",
-    "push",
-    "rumor",
-    "respect",
-    "specifi",
-    "support",
-    "abandon",
-    "figure",
-    "extend",
-    "tender",
-    "unveil",
-    "expose",
-    "industrializ",
-    "regulate",
-    "contract",
-    "lift",
-    "welcom",
-    "squeez",
-    "prolong",
-    "record",
-    "announce",
-    "assert",
-    "inch",
-    "manufacture",
-    "describe",
-    "calculate",
-    "favor",
-    "train",
-    "institut",
-    "concern",
-    "accelerat",
-    "solve",
-    "store",
-    "assembl",
-    "link",
-    "advertis",
-    "kick",
-    "scrambl",
-    "skyrocket",
-    "target",
-    "crippl",
-    "stress",
-    "manufactur",
-    "provoke",
-    "handle",
-    "poll",
-    "endors",
-    "balk",
-    "compensate",
-    "terminate",
-    "operate",
-    "admit",
-    "attract",
-    "feature",
-    "devote",
-    "triple",
-    "concentrat",
-    "plead",
-    "inspir",
-    "defend",
-    "treat",
-    "violat",
-    "enforce",
-    "surfac",
-    "concentrate",
-    "suffer",
-    "advis",
-    "interview",
-    "gauge",
-    "measur",
-    "hamper",
-    "nominat",
-    "assure",
-    "merge",
-    "achieve",
-    "retain",
-    "chair",
-    "relegat",
-    "mount",
-    "Ask",
-    "compil",
-    "Guarante",
-    "position",
-    "lock",
-    "roll",
-    "drift",
-    "Estimat",
-    "persuade",
-    "survive",
-    "Found",
-    "chastis",
-    "handl",
-    "press",
-    "sweeten",
-    "allocat",
-    "criticiz",
-    "place",
-    "prais",
-    "install",
-    "weigh",
-    "perceiv",
-    "remark",
-    "moderat",
-    "stat",
-    "rush",
-    "surpris",
-    "collaps",
-    "licens",
-    "disagree",
-    "publiciz",
-    "pressure",
-    "drive",
-    "omitt",
-    "assum",
-    "switch",
-    "define",
-    "sound",
-    "invent",
-    "absorb",
-    "found",
-    "observ",
-    "desir",
-    "sustain",
-    "welcome",
-    "load",
-    "engag",
-    "drove",
-    "pegg",
-    "compromise",
-    "enact",
-    "negotiate",
-    "result",
-    "prove",
-    "examine",
-    "connect",
-    "subscribe",
-    "organi",
-    "diminish",
-    "purchase",
-    "answer",
-    "orient",
-    "control",
-    "Post",
-    "succeed",
-    "rewrite",
-    "nominate",
-    "discharge",
-    "entrust",
-    "range",
-    "attempt",
-    "recover",
-    "maximize",
-    "engage",
-    "obligat",
-    "label",
-    "refuse",
-    "denounce",
-    "seize",
-    "halt",
-    "transform",
-    "contribute",
-    "tolerate",
-    "cool",
-    "overcome",
-    "caution",
-    "claim",
-    "discontinu",
-    "select",
-    "participate",
-    "bolster",
-    "devise",
-    "doubt",
-    "write",
-    "exchange",
-    "narrow",
-    "strike",
-    "diagnos",
-    "classif",
-    "outlaw",
-    "ventilat",
-    "slide",
-    "track",
-    "lengthen",
-    "ensnarl",
-    "oversee",
-    "renovat",
-    "accumulat",
-    "underscore",
-    "guarante",
-    "shore",
-    "evaluat",
-    "clutter",
-    "refile",
-    "expedit",
-    "disput",
-    "refund",
-    "scrapp",
-    "complicate",
-    "exist",
-    "Regard",
-    "halve",
-    "store",
-    "adapt",
-    "achiev",
-    "resume",
-    "assist",
-    "incorporat",
-    "capp",
-    "stake",
-    "outpac",
-    "burn",
-    "clobber",
-    "alarm",
-    "fatten",
-    "amend",
-    "book",
-    "watch",
-    "number",
-    "whistle",
-    "perpetuate",
-    "root",
-    "publish",
-    "abide",
-    "ration",
-    "host",
-    "assign",
-    "designat",
-    "survey",
-    "espouse",
-    "strapp",
-    "twinn",
-    "authoriz",
-    "paint",
-    "accru",
-    "swapp",
-    "obsess",
-    "Film",
-    "jostle",
-    "populat",
-    "curl",
-    "dream",
-    "resonate",
-    "glamorize",
-    "collaborat",
-    "enabl",
-    "chopp",
-    "celebrate",
-    "scatter",
-    "prosecute",
-    "unleash",
-    "Compare",
-    "superimpos",
-    "nurtur",
-    "shake",
-    "interrogat",
-    "clean",
-    "knitt",
-    "assemble",
-    "voice",
-    "monopolize",
-    "spott",
-    "Confront",
-    "underline",
-    "prosecut",
-    "enhanc",
-    "depend",
-    "inflat",
-    "educat",
-    "fad",
-    "stabb",
-    "resolv",
-    "usher",
-    "struggl",
-    "distinguish",
-    "prepare",
-    "copi",
-    "broke",
-    "car",
-    "crowd",
-    "decri",
-    "overus",
-    "enrag",
-    "expung",
-    "crank",
-    "touch",
-    "replicat",
-    "devis",
-    "replicate",
-    "discontinue",
-    "recommend",
-    "embroil",
-    "defuse",
-    "judg",
-    "polariz",
-    "discourage",
-    "regenerate",
-    "Rekindl",
-    "averag",
-    "protect",
-    "prohibit",
-    "initiat",
-    "mail",
-    "quipp",
-    "advocate",
-    "appoint",
-    "exhibit",
-    "empower",
-    "manipulate",
-    "specialize",
-    "summon",
-    "apologize",
-    "emerge",
-    "phase",
-    "fabricate",
-    "speculate",
-    "buoy",
-    "convinc",
-    "erode",
-    "trac",
-    "recede",
-    "flood",
-    "bill",
-    "alienat",
-    "portray",
-    "recycle",
-    "service",
-    "Develop",
-    "confuse",
-    "materialize",
-    "convert",
-    "equipp",
-    "depress",
-    "enclos",
-    "single",
-    "zoom",
-    "command",
-    "exhaust",
-    "yield",
-    "talk",
-    "excit",
-    "overpric",
-    "expir",
-    "postpon",
-    "reschedul",
-    "evaporat",
-    "rebuff",
-    "review",
-    "clamp",
-    "interest",
-    "license",
-    "patent",
-    "stirr",
-    "devot",
-    "escalat",
-    "clarifi",
-    "cross",
-    "penetrate",
-    "guid",
-    "milk",
-    "generate",
-    "double",
-    "compet",
-    "borrow",
-    "computerize",
-    "analyze",
-    "cultivat",
-    "tailor",
-    "delete",
-    "experience",
-    "troubl",
-    "institute",
-    "reopen",
-    "knock",
-    "synchronize",
-    "aggravat",
-    "anger",
-    "annoy",
-    "attend",
-    "evoke",
-    "scrape",
-    "state",
-    "memorize",
-    "muffl",
-    "stare",
-    "advance",
-    "fill",
-    "sack",
-    "entitl",
-    "dress",
-    "decorat",
-    "unsettl",
-    "breathe",
-    "tank",
-    "escap",
-    "declare",
-    "measure",
-    "infring",
-    "establish",
-    "lack",
-    "spoke",
-    "afflict",
-    "harp",
-    "seduce",
-    "remind",
-    "reprove",
-    "deteriorat",
-    "codifi",
-    "pull",
-    "acknowledge",
-    "hop",
-    "arriv",
-    "discard",
-    "click",
-    "visit",
-    "disapprove",
-    "defin",
-    "disciplin",
-    "Reach",
-    "rectifi",
-    "screw",
-    "block",
-    "emigrate",
-    "imagine",
-    "tighten",
-    "reap",
-    "ascribe",
-    "tout",
-    "acced",
-    "entice",
-    "pick",
-    "impress",
-    "entic",
-    "befuddl",
-    "possess",
-    "skipp",
-    "graduat",
-    "engineer",
-    "inherit",
-    "diversifi",
-    "provok",
-    "reallocate",
-    "stripp",
-    "reallocat",
-    "broaden",
-    "instruct",
-    "draft",
-    "waive",
-    "bounce",
-    "repair",
-    "propose",
-    "alter",
-    "correct",
-    "promis",
-    "impli",
-    "emphasiz",
-    "predispose",
-    "compos",
-    "quote",
-    "robb",
-    "bother",
-    "chose",
-    "participat",
-    "Choose",
-    "depriv",
-    "override",
-    "impede",
-    "impair",
-    "dubb",
-    "propagandize",
-    "clipp",
-    "transcribe",
-    "happen",
-    "disseminate",
-    "preclude",
-    "mention",
-    "examine",
-    "disagre",
-    "prescribe",
-    "assure",
-    "react",
-    "advocat",
-    "convince",
-    "exud",
-    "Annualiz",
-    "clash",
-    "evolv",
-    "enjoy",
-    "recruit",
-    "intimidate",
-    "Provid",
-    "predicat",
-    "constru",
-    "emasculate",
-    "ensure",
-    "wast",
-    "disapprov",
-    "invite",
-    "ratifi",
-    "characteriz",
-    "excise",
-    "sav",
-    "mortgag",
-    "reclaim",
-    "parch",
-    "profit",
-    "curtail",
-    "strengthen",
-    "cushion",
-    "materializ",
-    "flirt",
-    "fold",
-    "brighten",
-    "restor",
-    "headlin",
-    "hand",
-    "beleaguer",
-    "disclose",
-    "approach",
-    "screen",
-    "miss",
-    "preapprov",
-    "test-drive",
-    "retrac",
-    "account",
-    "vest",
-    "heat",
-    "exacerbat",
-    "telephone",
-    "wedd",
-    "wait",
-    "sneak",
-    "head",
-    "curb",
-    "battle",
-    "entrench",
-    "facilitate",
-    "stack",
-    "constitute",
-    "despise",
-    "frighten",
-    "manage",
-    "juggle",
-    "automat",
-    "dislike",
-    "spook",
-    "orchestrat",
-    "mint",
-    "chase",
-    "practic",
-    "arise",
-    "evolve",
-    "implement",
-    "decrease",
-    "sacrifice",
-    "Eliminate",
-    "please",
-    "advise",
-    "grapple",
-    "appropriat",
-    "stifle",
-    "notice",
-    "document",
-    "migrate",
-    "color",
-    "Fund",
-    "Concern",
-    "spurn",
-    "overvalu",
-    "recoup",
-    "hunt",
-    "promise",
-    "breath",
-    "enable",
-    "combine",
-    "insur",
-    "look",
-    "redistribute",
-    "field",
-    "concede",
-    "endorse",
-    "justifi",
-    "structur",
-    "downgrad",
-    "generat",
-    "arrang",
-    "overstat",
-    "circulat",
-    "midsiz",
-    "eclipse",
-    "stretch",
-    "debate",
-    "assess",
-    "revers",
-    "chill",
-    "insert",
-    "outnumber",
-    "surge",
-    "direct",
-    "stimulat",
-    "tempt",
-    "overdone",
-    "waive",
-    "notch",
-    "search",
-    "calculat",
-    "tackle",
-    "spackle",
-    "dispos",
-    "stay",
-    "revis",
-    "conduct",
-    "rank",
-    "blurr",
-    "compare",
-    "topp",
-    "outdistanc",
-    "relaunch",
-    "repric",
-    "guarantee",
-    "hail",
-    "despis",
-    "subsidize",
-    "appease",
-    "co-found",
-    "coordinate",
-    "heighten",
-    "nullifi",
-    "puzzl",
-    "challenge",
-    "notifi",
-    "clear",
-    "delist",
-    "explore",
-    "emerg",
-    "singl",
-    "sagg",
-    "grant",
-    "confus",
-    "complicat",
-    "Continu",
-    "ignor",
-    "secede",
-    "accrue",
-    "term",
-    "stemm",
-    "magnifi",
-    "reimburs",
-    "arrive",
-    "firm",
-    "falter",
-    "sense",
-    "distribut",
-    "experienc",
-    "customiz",
-    "deriv",
-    "avert",
-    "slat",
-    "realestate",
-    "reorganiz",
-    "plagu",
-    "bounc",
-    "reaffirm",
-    "demobilize",
-    "brush",
-    "sabotage",
-    "assassinat",
-    "avenge",
-    "pledg",
-    "defeat",
-    "rigg",
-    "subpoena",
-    "plant",
-    "explod",
-    "centraliz",
-    "fizzl",
-    "restructure",
-    "mitigate",
-    "reserv",
-    "batter",
-    "induce",
-    "investigate",
-    "estimate",
-    "question",
-    "trimm",
-    "detail",
-    "travel",
-    "plugg",
-    "fashion",
-    "arrest",
-    "Absorb",
-    "finaliz",
-    "lease",
-    "dash",
-    "sputter",
-    "harvest",
-    "gyrate",
-    "scrounge",
-    "alleviate",
-    "slow",
-    "deplete",
-    "relieve",
-    "compress",
-    "delay",
-    "influence",
-    "plummet",
-    "exceed",
-    "coat",
-    "scuttle",
-    "share",
+    "expect", "add", "report", "compare", "base", "close",
+    "offer", "price", "approve", "increase", "become", "propose", "decline",
+    "raise", "estimate", "call", "design", "acquire", "gain", "reach",
+    "announce", "fill", "became", "include", "decid", "disclose", "agree",
+    "fail", "complete", "raise", "trade", "continue", "include", "believe",
+    "receive", "schedule", "indicate", "provide", "help", "need", "cause",
+    "drop", "show", "order", "chang", "launch", "reduce", "plan", "want",
+    "follow", "trade", "improve", "issu", "involve", "reject", "increase",
+    "turn", "barr", "earn", "consent", "total", "acquire", "require", "prefer",
+    "produce", "introduce", "consider", "suspend", "prove", "open", "close",
+    "boost", "list", "prepare", "allow", "approve", "wrote", "reduce",
+    "advance", "describe", "produce", "operate", "surge", "jump", "provide",
+    "mature", "stop", "work", "introduce", "relate", "improve", "seem", "force",
+    "leave", "believe", "develop", "decline", "expire", "invest", "settle",
+    "change", "contribute", "elaborate", "refuse", "quote", "pass", "threaten",
+    "cause", "violate", "soar", "eliminate", "create", "replace", "argue",
+    "elect", "complete", "issue", "register", "pursue", "combine", "start",
+    "cover", "eliminate", "plunge", "contain", "manag", "suggest", "appear",
+    "discover", "oppose", "form", "limit", "force", "disgorge", "attribut",
+    "studi", "resign", "settl", "retire", "move", "anticipat", "decide",
+    "prompt", "maintain", "rang", "focus", "climb", "adjust", "award", "carri",
+    "identif", "confirm", "match", "conclude", "sign", "adopt", "accept",
+    "expand", "exercise", "finish", "finance", "charge", "realize", "remain",
+    "express", "replace", "deliver", "dump", "import", "assume", "capture",
+    "join", "releas", "lower", "exce", "determin", "locat", "appli", "complain",
+    "trigger", "enter", "intend", "purchas", "blam", "learn", "renew", "view",
+    "speculat", "choose", "respond", "encourage", "dismiss", "realiz", "serve",
+    "associat", "slipp", "spark", "negotiate", "pleas", "divid", "financ",
+    "execute", "discuss", "hir", "reflect", "determine", "market", "warn",
+    "qualifi", "explain", "impose", "recognize", "indicate", "point", "collect",
+    "benefit", "attach", "compete", "incurr", "remove", "share", "request",
+    "permit", "remove", "revive", "predict", "couple", "play", "commit",
+    "revive", "kill", "present", "deserve", "convict", "agree", "accommodate",
+    "surrender", "restore", "restructur", "fear", "represent", "fund",
+    "involve", "redeem", "resolve", "obtain", "employ", "promote", "impose",
+    "insist", "contact", "print", "advertise", "damage", "exercis", "auction",
+    "disappoint", "subordinat", "secure", "integrat", "perform", "stepp",
+    "regulat", "trail", "occurr", "expell", "amount", "back", "regard",
+    "conclude", "dominat", "push", "rumor", "respect", "specifi", "support",
+    "abandon", "figure", "extend", "tender", "unveil", "expose", "industrializ",
+    "regulate", "contract", "lift", "welcom", "squeez", "prolong", "record",
+    "announce", "assert", "inch", "manufacture", "describe", "calculate",
+    "favor", "train", "institut", "concern", "accelerat", "solve", "store",
+    "assembl", "link", "advertis", "kick", "scrambl", "skyrocket", "target",
+    "crippl", "stress", "manufactur", "provoke", "handle", "poll", "endors",
+    "balk", "compensate", "terminate", "operate", "admit", "attract", "feature",
+    "devote", "triple", "concentrat", "plead", "inspir", "defend", "treat",
+    "violat", "enforce", "surfac", "concentrate", "suffer", "advis",
+    "interview", "gauge", "measur", "hamper", "nominat", "assure", "merge",
+    "achieve", "retain", "chair", "relegat", "mount", "Ask", "compil",
+    "Guarante", "position", "lock", "roll", "drift", "Estimat", "persuade",
+    "survive", "Found", "chastis", "handl", "press", "sweeten", "allocat",
+    "criticiz", "place", "prais", "install", "weigh", "perceiv", "remark",
+    "moderat", "stat", "rush", "surpris", "collaps", "licens", "disagree",
+    "publiciz", "pressure", "drive", "omitt", "assum", "switch", "define",
+    "sound", "invent", "absorb", "found", "observ", "desir", "sustain",
+    "welcome", "load", "engag", "drove", "pegg", "compromise", "enact",
+    "negotiate", "result", "prove", "examine", "connect", "subscribe", "organi",
+    "diminish", "purchase", "answer", "orient", "control", "Post", "succeed",
+    "rewrite", "nominate", "discharge", "entrust", "range", "attempt",
+    "recover", "maximize", "engage", "obligat", "label", "refuse", "denounce",
+    "seize", "halt", "transform", "contribute", "tolerate", "cool", "overcome",
+    "caution", "claim", "discontinu", "select", "participate", "bolster",
+    "devise", "doubt", "write", "exchange", "narrow", "strike", "diagnos",
+    "classif", "outlaw", "ventilat", "slide", "track", "lengthen", "ensnarl",
+    "oversee", "renovat", "accumulat", "underscore", "guarante", "shore",
+    "evaluat", "clutter", "refile", "expedit", "disput", "refund", "scrapp",
+    "complicate", "exist", "Regard", "halve", "store", "adapt", "achiev",
+    "resume", "assist", "incorporat", "capp", "stake", "outpac", "burn",
+    "clobber", "alarm", "fatten", "amend", "book", "watch", "number", "whistle",
+    "perpetuate", "root", "publish", "abide", "ration", "host", "assign",
+    "designat", "survey", "espouse", "strapp", "twinn", "authoriz", "paint",
+    "accru", "swapp", "obsess", "Film", "jostle", "populat", "curl", "dream",
+    "resonate", "glamorize", "collaborat", "enabl", "chopp", "celebrate",
+    "scatter", "prosecute", "unleash", "Compare", "superimpos", "nurtur",
+    "shake", "interrogat", "clean", "knitt", "assemble", "voice", "monopolize",
+    "spott", "Confront", "underline", "prosecut", "enhanc", "depend", "inflat",
+    "educat", "fad", "stabb", "resolv", "usher", "struggl", "distinguish",
+    "prepare", "copi", "broke", "car", "crowd", "decri", "overus", "enrag",
+    "expung", "crank", "touch", "replicat", "devis", "replicate", "discontinue",
+    "recommend", "embroil", "defuse", "judg", "polariz", "discourage",
+    "regenerate", "Rekindl", "averag", "protect", "prohibit", "initiat", "mail",
+    "quipp", "advocate", "appoint", "exhibit", "empower", "manipulate",
+    "specialize", "summon", "apologize", "emerge", "phase", "fabricate",
+    "speculate", "buoy", "convinc", "erode", "trac", "recede", "flood", "bill",
+    "alienat", "portray", "recycle", "service", "Develop", "confuse",
+    "materialize", "convert", "equipp", "depress", "enclos", "single", "zoom",
+    "command", "exhaust", "yield", "talk", "excit", "overpric", "expir",
+    "postpon", "reschedul", "evaporat", "rebuff", "review", "clamp", "interest",
+    "license", "patent", "stirr", "devot", "escalat", "clarifi", "cross",
+    "penetrate", "guid", "milk", "generate", "double", "compet", "borrow",
+    "computerize", "analyze", "cultivat", "tailor", "delete", "experience",
+    "troubl", "institute", "reopen", "knock", "synchronize", "aggravat",
+    "anger", "annoy", "attend", "evoke", "scrape", "state", "memorize", "muffl",
+    "stare", "advance", "fill", "sack", "entitl", "dress", "decorat", "unsettl",
+    "breathe", "tank", "escap", "declare", "measure", "infring", "establish",
+    "lack", "spoke", "afflict", "harp", "seduce", "remind", "reprove",
+    "deteriorat", "codifi", "pull", "acknowledge", "hop", "arriv", "discard",
+    "click", "visit", "disapprove", "defin", "disciplin", "Reach", "rectifi",
+    "screw", "block", "emigrate", "imagine", "tighten", "reap", "ascribe",
+    "tout", "acced", "entice", "pick", "impress", "entic", "befuddl", "possess",
+    "skipp", "graduat", "engineer", "inherit", "diversifi", "provok",
+    "reallocate", "stripp", "reallocat", "broaden", "instruct", "draft",
+    "waive", "bounce", "repair", "propose", "alter", "correct", "promis",
+    "impli", "emphasiz", "predispose", "compos", "quote", "robb", "bother",
+    "chose", "participat", "Choose", "depriv", "override", "impede", "impair",
+    "dubb", "propagandize", "clipp", "transcribe", "happen", "disseminate",
+    "preclude", "mention", "examine", "disagre", "prescribe", "assure", "react",
+    "advocat", "convince", "exud", "Annualiz", "clash", "evolv", "enjoy",
+    "recruit", "intimidate", "Provid", "predicat", "constru", "emasculate",
+    "ensure", "wast", "disapprov", "invite", "ratifi", "characteriz", "excise",
+    "sav", "mortgag", "reclaim", "parch", "profit", "curtail", "strengthen",
+    "cushion", "materializ", "flirt", "fold", "brighten", "restor", "headlin",
+    "hand", "beleaguer", "disclose", "approach", "screen", "miss", "preapprov",
+    "test-drive", "retrac", "account", "vest", "heat", "exacerbat", "telephone",
+    "wedd", "wait", "sneak", "head", "curb", "battle", "entrench", "facilitate",
+    "stack", "constitute", "despise", "frighten", "manage", "juggle", "automat",
+    "dislike", "spook", "orchestrat", "mint", "chase", "practic", "arise",
+    "evolve", "implement", "decrease", "sacrifice", "Eliminate", "please",
+    "advise", "grapple", "appropriat", "stifle", "notice", "document",
+    "migrate", "color", "Fund", "Concern", "spurn", "overvalu", "recoup",
+    "hunt", "promise", "breath", "enable", "combine", "insur", "look",
+    "redistribute", "field", "concede", "endorse", "justifi", "structur",
+    "downgrad", "generat", "arrang", "overstat", "circulat", "midsiz",
+    "eclipse", "stretch", "debate", "assess", "revers", "chill", "insert",
+    "outnumber", "surge", "direct", "stimulat", "tempt", "overdone", "waive",
+    "notch", "search", "calculat", "tackle", "spackle", "dispos", "stay",
+    "revis", "conduct", "rank", "blurr", "compare", "topp", "outdistanc",
+    "relaunch", "repric", "guarantee", "hail", "despis", "subsidize", "appease",
+    "co-found", "coordinate", "heighten", "nullifi", "puzzl", "challenge",
+    "notifi", "clear", "delist", "explore", "emerg", "singl", "sagg", "grant",
+    "confus", "complicat", "Continu", "ignor", "secede", "accrue", "term",
+    "stemm", "magnifi", "reimburs", "arrive", "firm", "falter", "sense",
+    "distribut", "experienc", "customiz", "deriv", "avert", "slat",
+    "realestate", "reorganiz", "plagu", "bounc", "reaffirm", "demobilize",
+    "brush", "sabotage", "assassinat", "avenge", "pledg", "defeat", "rigg",
+    "subpoena", "plant", "explod", "centraliz", "fizzl", "restructure",
+    "mitigate", "reserv", "batter", "induce", "investigate", "estimate",
+    "question", "trimm", "detail", "travel", "plugg", "fashion", "arrest",
+    "Absorb", "finaliz", "lease", "dash", "sputter", "harvest", "gyrate",
+    "scrounge", "alleviate", "slow", "deplete", "relieve", "compress", "delay",
+    "influence", "plummet", "exceed", "coat", "scuttle", "share",
 ]
 
 secrets_regex = {
@@ -1204,19 +318,19 @@ secrets_regex = {
         ),
         re.compile(r"""(?i)aws(.{0,20})?['"][0-9a-zA-Z/+]{40}['"]"""),
         re.compile(
-            r"""amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"""
+            r"""amzn.mws.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"""
         ),
         re.compile(r"da2-[a-z0-9]{26}"),
-        re.compile(r"s3\\.amazonaws\\.com"),
-        re.compile(r"ec2-[0-9a-z.\\-_]+\\.compute(-1)?\\.amazonaws\\.com"),
-        re.compile(r"[0-9a-z.\\-_]+\\.elb\\.[0-9a-z.\\-_]+\\.amazonaws\\.com"),
-        re.compile(r"[0-9a-z.\\-_]+\\.rds\\.amazonaws\\.com"),
-        re.compile(r"[0-9a-z.\\-_]+\\.cache\\.amazonaws\\.com"),
+        re.compile(r"s3.amazonaws.com"),
+        re.compile(r"ec2-[0-9a-z.-_]+.compute(-1)?.amazonaws.com"),
+        re.compile(r"[0-9a-z.-_]+.elb.[0-9a-z.-_]+.amazonaws.com"),
+        re.compile(r"[0-9a-z.-_]+.rds.amazonaws\\.com"),
+        re.compile(r"[0-9a-z.-_]+.cache.amazonaws.com"),
         re.compile(
-            r"[0-9a-z.\\-_]+\\.s3-website[0-9a-z.\\-_]+\\.amazonaws\\.com"
+            r"[0-9a-z.-_]+.s3-website[0-9a-z.-_]+.amazonaws.com"
         ),
         re.compile(
-            r"[0-9a-z]+\\.execute-api\\.[0-9a-z.\\-_]+\\.amazonaws\\.com"
+            r"[0-9a-z]+.execute-api.[0-9a-z.\-_]+.amazonaws.com"
         ),
     ],
     "github": [
@@ -1231,15 +345,15 @@ secrets_regex = {
     "RSA": [re.compile(r"""-----BEGIN RSA PRIVATE KEY-----""")],
     "PGP": [re.compile(r"""-----BEGIN PGP PRIVATE KEY-----""")],
     "google": [
-        re.compile(r"""AIza[0-9A-Za-z\\-_]{35}"""),
+        re.compile(r"""AIza[0-9A-Za-z\-_]{35}"""),
         re.compile(
-            r"""[sS][eE][cC][rR][eE][tT].*['|"][0-9a-zA-Z]{32,45}['|"]"""
+            r"""[sS][eE][cC][rR][eE][tT].*['"][0-9a-zA-Z]{32,45}['"]"""
         ),
         re.compile(
-            r"""[sS][eE][cC][rR][eE][tT].*['|"][0-9a-zA-Z]{32,45}['|"]"""
+            r"""[sS][eE][cC][rR][eE][tT].*['"][0-9a-zA-Z]{32,45}['"]"""
         ),
         re.compile(
-            r"""[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com"""
+            r"""[0-9]+-[0-9A-Za-z_]{32}.apps.googleusercontent.com"""
         ),
     ],
     "heroku": [
@@ -1269,12 +383,12 @@ secrets_regex = {
     ],
     "twilio": [re.compile(r"""(?i)twilio(.{0,20})?['"][0-9a-f]{32}['"]""")],
     "dynatrace": [
-        re.compile(r"""dt0[a-zA-Z]{1}[0-9]{2}\.[A-Z0-9]{24}\.[A-Z0-9]{64}""")
+        re.compile(r"""dt0[a-zA-Z][0-9]{2}\.[A-Z0-9]{24}\.[A-Z0-9]{64}""")
     ],
     "url": [
         re.compile(r"""(http(s)?|s3)://"""),
         re.compile(
-            r"""[a-zA-Z]{3,10}://[^/\\s:@]{3,20}:[^/\\s:@]{3,20}@.{1,100}["'\\s]"""
+            r"""[a-zA-Z]{3,10}://[^/\s:@]{3,20}:[^/\s:@]{3,20}@.{1,100}["'\s]"""
         ),
         re.compile(
             r"(ftp|jdbc:mysql)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]"
@@ -1282,42 +396,76 @@ secrets_regex = {
     ],
     "authorization": [
         re.compile(
-            r"(authorization)\\s*:\\s*(bearer|token|basic)\\s+[0-9a-z\\.\\-_]{6,}"
+            r"(authorization)\s*:\s*(bearer|token|basic)\s+[0-9a-z.\-_]{6,}"
         ),
         re.compile(r"eyJ[A-Za-z0-9_/+-]*\.[A-Za-z0-9._/+-]*"),
     ],
     "email": [
         re.compile(
-            r"(?<=mailto:)[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9.-]+"
+            r"(?<=mailto:)[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+.[a-zA-Z0-9.-]+"
         )
     ],
     "ip": [
         re.compile(
-            r"^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"
+            r"^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]).){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"
         )
     ],
 }
 
 
 def is_base64(s):
+    """
+    Checks if the given string is a valid Base64 encoded string.
+
+    Args:
+        s (str or bytes): The string to be checked.
+
+    Returns:
+        bool: True if the string is a valid Base64 encoded string.
+    """
     try:
-        return s.endswith("==") or base64.b64encode(base64.b64decode(s)) == s
-    except Exception:
+        decoded = base64.b64decode(s)
+        return s.endswith("==") or base64.b64encode(decoded) == s.encode()
+    except (binascii.Error, TypeError, UnicodeError):
         return False
 
 
 def decode_base64(s):
+    """
+    This function decodes a Base64 encoded string. It first removes any newline
+    characters from the input string. Then, it checks if the string is a valid
+    Base64 encoded string using the `is_base64` function. If it is valid, the
+    string is decoded using the Base64 decoding algorithm. If the decoded string
+    can be successfully decoded as UTF-8, the decoded string is returned.
+    Otherwise, the decoded string is returned as a byte string. If the input
+    string is not a valid Base64 encoded string, it is returned as is.
+
+    Args:
+        s (str or bytes): The Base64 encoded string to be decoded.
+
+    Returns:
+      - str or bytes: Decoded string, either a UTF-8 string or a byte string.
+    """
     s = s.replace("\n", "")
     if is_base64(s):
         decoded = base64.b64decode(s)
         try:
             return decoded.decode()
-        except Exception:
+        except (binascii.Error, UnicodeError):
             return str(decoded)
     return s
 
 
 def is_camel_case(s):
+    """
+    Checks if the given string follows the camel case naming convention.
+
+    Args:
+        s (str): The string to be checked.
+
+    Returns:
+        bool: True if the string follows the camel case naming convention.
+    """
     s = re.sub(r"[*._#%&!\"]", "", s)
     for x in string.digits:
         if x in s:
@@ -1329,54 +477,94 @@ def is_camel_case(s):
 
 
 def calculate_entropy(data):
+    """
+    This function calculates the entropy of the given data to measure its
+    randomness or predictability. It first performs checks to handle special
+    cases, such as empty data or data with a length less than 8. Then, it
+    removes certain protocol prefixes from the data to reduce false positives.
+    Next, it calculates the entropy based on the character frequencies in the
+    data using the Shannon entropy formula. The entropy value represents the
+    amount of uncertainty or randomness in the data. Finally, it applies
+    additional conditions to adjust the entropy value based on the data's
+    characteristics.
+
+    Args:
+        data: The data for which entropy needs to be calculated.
+
+    Returns:
+        float: The calculated entropy value.
+    """
     if not data or len(data) < 8:
         return 0
-    for text in strings_allowlist:
-        if text in data:
-            return 0
+
+    if any(text in data for text in strings_allowlist):
+        return 0
+
     entropy = 0.0
+
     # Remove protocol prefixes which tend to increase false positives
     data = re.sub(r"(file|s3|http(s)?|email|ftp)://", "", data)
+
     if not data:
         return entropy
-    digit_found = False
-    punctuation_found = False
-    ascii_found = False
-    for x in charset:
-        p_x = float(data.count(x)) / len(data)
-        if p_x > 0:
-            if not ascii_found and x in string.ascii_letters:
-                ascii_found = True
-            if not digit_found and x in string.digits:
-                digit_found = True
-            if not punctuation_found and x in string.punctuation:
-                punctuation_found = True
-            entropy += -p_x * math.log(p_x, 256)
+
+    char_count = {}
+    for char in data:
+        char_count[char] = char_count.get(char, 0) + 1
+
+    total_chars = len(data)
+    ascii_found = any(char in string.ascii_letters for char in char_count)
+    digit_found = any(char in string.digits for char in char_count)
+    punctuation_found = any(char in string.punctuation for char in char_count)
+
+    for count in char_count.values():
+        p_x = count / total_chars
+        entropy += -p_x * math.log(p_x, 256)
+
     if is_camel_case(data) or data.lower() == data or data.upper() == data:
         return min(0.2, round(entropy, 2))
-    if ascii_found and (digit_found or punctuation_found):
-        if not punctuation_found:
-            return min(0.38, round(entropy, 2))
-        return round(entropy, 2)
-    else:
+
+    if not ascii_found or (not digit_found and not punctuation_found):
         return min(0.4, round(entropy, 2))
+
+    return round(entropy, 2) if punctuation_found else min(0.38,
+                                                           round(entropy, 2))
 
 
 def check_secret(data):
-    for text in strings_allowlist:
-        if text in data:
-            return None
+    """
+    This function checks if the given data contains any secrets. It first checks
+    if any strings from the allowlist are present in the data. If so, it returns
+    an empty string to indicate no secrets found. Then, it iterates over a set
+    of regular expressions categorized by secrets and checks if any of the
+    regular expressions match the data. If a match is found, it returns the
+    corresponding category. If no secrets are found, it returns an empty string.
+
+    Args:
+      - data: The data to be checked for secrets.
+
+    Returns:
+        str: The category of the secret if found, otherwise an empty string.
+    """
+    if any(text in data for text in strings_allowlist):
+        return ""
+
     for category, rlist in secrets_regex.items():
         for regex in rlist:
-            for match in regex.findall(data):
+            if regex.search(data):
                 return category
-    return None
+
+    return ""
 
 
 def is_binary_string(content):
     """
     Method to check if the given content is a binary string
     """
+    # text_chars = bytearray(
+    #     {7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F})
+    # return bool(
+    #     content.translate(bytes.maketrans(b"", text_chars)))
     textchars = bytearray(
         {7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F}
     )
@@ -1395,23 +583,23 @@ def is_ignored_file(file_name):
     extn = "".join(Path(file_name).suffixes)
     if extn in ignore_files or file_name in ignore_files:
         return True
-    for ie in ignore_files:
-        if file_name.endswith(ie):
-            return True
-    return False
+    return any(file_name.endswith(ie) for ie in ignore_files)
 
 
 def is_exe(src):
-    """Detect if the source is a binary file
+    """
+    Detect if the source is a binary file
 
-    :param src: Source path
+    Args:
+        src: Source path
 
-    :return True if binary file. False otherwise.
+    Returns:
+         bool: True if binary file. False otherwise.
     """
     if os.path.isfile(src):
         try:
             return is_binary_string(open(src, "rb").read(1024))
-        except Exception:
+        except (AttributeError, TypeError, PermissionError):
             return False
     return False
 
@@ -1419,20 +607,29 @@ def is_exe(src):
 def filter_ignored_dirs(dirs):
     """
     Method to filter directory list to remove ignored directories
-    :param dirs: Directories to ignore
-    :return: Filtered directory list
+
+    Args:
+        dirs: Directories
+
+    Returns:
+        list: Filtered list of directories
     """
-    [
+    return [
         dirs.remove(d)
         for d in list(dirs)
         if d.lower() in ignore_directories or d.startswith(".")
     ]
-    return dirs
 
 
 def find_exe_files(src):
     """
-    Method to find files with given extenstion
+    Method to find files with given extension
+
+    Args:
+        src (str): Source path
+
+    Returns:
+        list: List of filtered files
     """
     result = []
     for root, dirs, files in os.walk(src):
@@ -1440,9 +637,9 @@ def find_exe_files(src):
         for file in files:
             if is_ignored_file(file):
                 continue
-            fullPath = os.path.join(root, file)
-            if is_exe(fullPath):
-                result.append(fullPath)
+            full_path = os.path.join(root, file)
+            if is_exe(full_path):
+                result.append(full_path)
     return result
 
 
@@ -1463,53 +660,119 @@ def find_files(path, extns):
     """
     result = []
     if os.path.isfile(path):
-        for ext in extns:
-            if path.endswith(ext):
-                result.append(path)
+        result.extend(path for ext in extns if path.endswith(ext))
     else:
         for root, dirs, files in os.walk(path):
             filter_ignored_dirs(dirs)
             for file in files:
-                for ext in extns:
-                    if file.endswith(ext):
-                        result.append(os.path.join(root, file))
+                result.extend(
+                    os.path.join(root, file)
+                    for ext in extns if file.endswith(ext)
+                )
     return result
 
 
-def bomstrip(manifest):
+def bom_strip(manifest):
     """
     Function to delete UTF-8 BOM character in "string"
+
+    Args:
+        manifest (str): Executable manifest
+
+    Returns:
+        str: Manifest without BOM character
     """
-    utf8bom = b"\xef\xbb\xbf"
-    if manifest[:3] == utf8bom:
-        return manifest[3:]
-    else:
-        return manifest
+    utf8_bom = b"\xef\xbb\xbf"
+    return manifest[3:] if manifest[:3] == utf8_bom else manifest
 
 
 def parse_pe_manifest(manifest):
     """
     Method to parse xml pe manifest
-    :param manifest: String manifest
-    :return: dict with flattened keys and values
+
+    Args:
+        manifest (str): Executable manifest
+
+    Returns:
+        dict: Parsed manifest with flattened keys and values
     """
     try:
         attribs_dict = {}
-        root = fromstring(bomstrip(manifest))
+        root = fromstring(bom_strip(manifest))
         for child in root:
             for ele in child.iter():
                 attribs_dict[ele.tag.rpartition("}")[-1]] = ele.attrib
         return attribs_dict
-    except Exception:
-        return None
+    except (TypeError, AttributeError, IndexError):
+        return {}
 
 
 def is_fuzzable_name(name_str):
+    """
+    This function checks if a given name string is fuzzable.
+    """
     if name_str:
-        for n in fuzzable_names:
-            if n.lower() in name_str:
-                return True
-        return False
+        return any(n.lower() in name_str for n in fuzzable_names)
+    return ""
+
+
+def print_findings_table(findings, files):
+    """
+    Prints the findings in a formatted table.
+
+    This function takes a list of findings and a list of files, and prints the
+    findings in a table format. The table includes columns for ID, Binary (if
+    multiple files), Title, and Severity.
+
+    Args:
+        findings (list[dict]): A list of dictionaries representing the findings
+        files (list[str]): A list of files.
+    """
+    table = Table(
+        title="BLint Findings", box=box.DOUBLE_EDGE,
+        header_style="bold magenta", show_lines=True,
+    )
+    table.add_column("ID")
+    if len(files) > 1:
+        table.add_column("Binary")
+    table.add_column("Title")
+    table.add_column("Severity")
+    for f in findings:
+        severity = f.get("severity").upper()
+        severity_fmt = (
+            f'{"[bright_red]" if severity in ("CRITICAL", "HIGH") else ""}'
+            f'{severity}')
+        if len(files) > 1:
+            table.add_row(
+                f.get("id"), f.get("exe_name"), f.get("title"), severity_fmt, )
+        else:
+            table.add_row(f.get("id"), f.get("title"), severity_fmt, )
+    console.print(table)
+
+
+def gen_file_list(src):
+    """Generates a list of files from the given source.
+
+    This function generates a list of executable files from a source directory
+    or identifies a file.
+
+    Args:
+        src (str): A source file/directory
+
+    Returns:
+        list: A list of files.
+    """
+    files = []
+    for s in src:
+        if os.path.isdir(s):
+            files += find_exe_files(s)
+        else:
+            if is_ignored_file(s):
+                continue
+            full_path = os.path.abspath(s)
+            if is_exe(full_path):
+                files.append(full_path)
+    return files
 
 
 def unzip_unsafe(zf, to_dir):
@@ -1532,3 +795,50 @@ def get_version():
     Returns the version of depscan
     """
     return distribution("blint").version
+
+
+def cleanup_dict_lief_errors(old_dict):
+    """
+    Removes lief_errors from a dictionary recursively.
+
+    Args:
+        old_dict (dict): The dictionary to remove lief_errors from.
+
+    Returns:
+        dict: A new dictionary with lief_errors removed.
+
+    """
+    new_dict = {}
+    for key, value in old_dict.items():
+        if isinstance(value, lief_errors):
+            continue
+        if isinstance(value, dict):
+            entry = cleanup_dict_lief_errors(value)
+        elif isinstance(value, list):
+            entry = cleanup_list_lief_errors(value)
+        else:
+            entry = value
+        new_dict[key] = entry
+    return new_dict
+
+
+def cleanup_list_lief_errors(d):
+    """
+    Cleans up a list by removing lief errors recursively.
+
+    :param d: The list to be cleaned up.
+
+    :return: The new list
+    """
+    new_lst = []
+    for dl in d:
+        if isinstance(dl, lief_errors):
+            continue
+        if isinstance(dl, dict):
+            entry = cleanup_dict_lief_errors(dl)
+        elif isinstance(dl, list):
+            entry = cleanup_list_lief_errors(dl)
+        else:
+            entry = dl
+        new_lst.append(entry)
+    return new_lst

--- a/poetry.lock
+++ b/poetry.lock
@@ -24,33 +24,33 @@ files = [
 
 [[package]]
 name = "black"
-version = "24.1.1"
+version = "24.2.0"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "black-24.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2588021038bd5ada078de606f2a804cadd0a3cc6a79cb3e9bb3a8bf581325a4c"},
-    {file = "black-24.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1a95915c98d6e32ca43809d46d932e2abc5f1f7d582ffbe65a5b4d1588af7445"},
-    {file = "black-24.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fa6a0e965779c8f2afb286f9ef798df770ba2b6cee063c650b96adec22c056a"},
-    {file = "black-24.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:5242ecd9e990aeb995b6d03dc3b2d112d4a78f2083e5a8e86d566340ae80fec4"},
-    {file = "black-24.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fc1ec9aa6f4d98d022101e015261c056ddebe3da6a8ccfc2c792cbe0349d48b7"},
-    {file = "black-24.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0269dfdea12442022e88043d2910429bed717b2d04523867a85dacce535916b8"},
-    {file = "black-24.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3d64db762eae4a5ce04b6e3dd745dcca0fb9560eb931a5be97472e38652a161"},
-    {file = "black-24.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:5d7b06ea8816cbd4becfe5f70accae953c53c0e53aa98730ceccb0395520ee5d"},
-    {file = "black-24.1.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e2c8dfa14677f90d976f68e0c923947ae68fa3961d61ee30976c388adc0b02c8"},
-    {file = "black-24.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a21725862d0e855ae05da1dd25e3825ed712eaaccef6b03017fe0853a01aa45e"},
-    {file = "black-24.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07204d078e25327aad9ed2c64790d681238686bce254c910de640c7cc4fc3aa6"},
-    {file = "black-24.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:a83fe522d9698d8f9a101b860b1ee154c1d25f8a82ceb807d319f085b2627c5b"},
-    {file = "black-24.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:08b34e85170d368c37ca7bf81cf67ac863c9d1963b2c1780c39102187ec8dd62"},
-    {file = "black-24.1.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7258c27115c1e3b5de9ac6c4f9957e3ee2c02c0b39222a24dc7aa03ba0e986f5"},
-    {file = "black-24.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40657e1b78212d582a0edecafef133cf1dd02e6677f539b669db4746150d38f6"},
-    {file = "black-24.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e298d588744efda02379521a19639ebcd314fba7a49be22136204d7ed1782717"},
-    {file = "black-24.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:34afe9da5056aa123b8bfda1664bfe6fb4e9c6f311d8e4a6eb089da9a9173bf9"},
-    {file = "black-24.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:854c06fb86fd854140f37fb24dbf10621f5dab9e3b0c29a690ba595e3d543024"},
-    {file = "black-24.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3897ae5a21ca132efa219c029cce5e6bfc9c3d34ed7e892113d199c0b1b444a2"},
-    {file = "black-24.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:ecba2a15dfb2d97105be74bbfe5128bc5e9fa8477d8c46766505c1dda5883aac"},
-    {file = "black-24.1.1-py3-none-any.whl", hash = "sha256:5cdc2e2195212208fbcae579b931407c1fa9997584f0a415421748aeafff1168"},
-    {file = "black-24.1.1.tar.gz", hash = "sha256:48b5760dcbfe5cf97fd4fba23946681f3a81514c6ab8a45b50da67ac8fbc6c7b"},
+    {file = "black-24.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6981eae48b3b33399c8757036c7f5d48a535b962a7c2310d19361edeef64ce29"},
+    {file = "black-24.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d533d5e3259720fdbc1b37444491b024003e012c5173f7d06825a77508085430"},
+    {file = "black-24.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61a0391772490ddfb8a693c067df1ef5227257e72b0e4108482b8d41b5aee13f"},
+    {file = "black-24.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:992e451b04667116680cb88f63449267c13e1ad134f30087dec8527242e9862a"},
+    {file = "black-24.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:163baf4ef40e6897a2a9b83890e59141cc8c2a98f2dda5080dc15c00ee1e62cd"},
+    {file = "black-24.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e37c99f89929af50ffaf912454b3e3b47fd64109659026b678c091a4cd450fb2"},
+    {file = "black-24.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f9de21bafcba9683853f6c96c2d515e364aee631b178eaa5145fc1c61a3cc92"},
+    {file = "black-24.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:9db528bccb9e8e20c08e716b3b09c6bdd64da0dd129b11e160bf082d4642ac23"},
+    {file = "black-24.2.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d84f29eb3ee44859052073b7636533ec995bd0f64e2fb43aeceefc70090e752b"},
+    {file = "black-24.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e08fb9a15c914b81dd734ddd7fb10513016e5ce7e6704bdd5e1251ceee51ac9"},
+    {file = "black-24.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:810d445ae6069ce64030c78ff6127cd9cd178a9ac3361435708b907d8a04c693"},
+    {file = "black-24.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:ba15742a13de85e9b8f3239c8f807723991fbfae24bad92d34a2b12e81904982"},
+    {file = "black-24.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7e53a8c630f71db01b28cd9602a1ada68c937cbf2c333e6ed041390d6968faf4"},
+    {file = "black-24.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:93601c2deb321b4bad8f95df408e3fb3943d85012dddb6121336b8e24a0d1218"},
+    {file = "black-24.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0057f800de6acc4407fe75bb147b0c2b5cbb7c3ed110d3e5999cd01184d53b0"},
+    {file = "black-24.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:faf2ee02e6612577ba0181f4347bcbcf591eb122f7841ae5ba233d12c39dcb4d"},
+    {file = "black-24.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:057c3dc602eaa6fdc451069bd027a1b2635028b575a6c3acfd63193ced20d9c8"},
+    {file = "black-24.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:08654d0797e65f2423f850fc8e16a0ce50925f9337fb4a4a176a7aa4026e63f8"},
+    {file = "black-24.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca610d29415ee1a30a3f30fab7a8f4144e9d34c89a235d81292a1edb2b55f540"},
+    {file = "black-24.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:4dd76e9468d5536abd40ffbc7a247f83b2324f0c050556d9c371c2b9a9a95e31"},
+    {file = "black-24.2.0-py3-none-any.whl", hash = "sha256:e8a6ae970537e67830776488bca52000eaa37fa63b9988e8c487458d9cd5ace6"},
+    {file = "black-24.2.0.tar.gz", hash = "sha256:bce4f25c27c3435e4dace4815bcb2008b87e167e3bf4ee47ccdc5ce906eb4894"},
 ]
 
 [package.dependencies]
@@ -260,41 +260,41 @@ files = [
 
 [[package]]
 name = "lief"
-version = "0.14.0"
+version = "0.14.1"
 description = "Library to instrument executable formats"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "lief-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b1e9af189e0dcbd6ce9ce67266135ef288c9b8f9a5efe2a47d0d0266288713cf"},
-    {file = "lief-0.14.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:60be24af0b913a79922a9730302df5f380954a1d7b1c0c7de91b8918e36f0756"},
-    {file = "lief-0.14.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:1d949c53f95132ef0d218e88c3c982610c54426249c95f99b736e5c15bb1b75b"},
-    {file = "lief-0.14.0-cp310-cp310-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:51e7adfe1cc574a035b47a280cb5902cec6deb2d78ef0b47c536bdd75dfa6956"},
-    {file = "lief-0.14.0-cp310-cp310-win32.whl", hash = "sha256:b34708c002c119f43998af3c4f219d06de6b66a34aceb298fd8bba8247e57572"},
-    {file = "lief-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:684c1500fddab8aaf5a4f74cd092ea190c4c837d31c5d087c68a9f175775c2db"},
-    {file = "lief-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:737bd6fab74e222968936794e09b2bf399417c38a3bc13d6ad70836793e78586"},
-    {file = "lief-0.14.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:ff42aa1f12d3dc8bc5641eb1991269fb92e43bae386559ad576c97ffa09639f2"},
-    {file = "lief-0.14.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:69df631cd0573388fa6891277d006f8da2fa42a5bbe3acc440b66a7352f6bef3"},
-    {file = "lief-0.14.0-cp311-cp311-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:b850f38b62ca8a92c7f9803ceac0e79369b732a75e627cba3c2b8f1fa729f643"},
-    {file = "lief-0.14.0-cp311-cp311-win32.whl", hash = "sha256:ba29aabd72e92334d54883d58b108f80465973edaec3e27cb422abbc657bfe17"},
-    {file = "lief-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:33f2afdf9f00a8a208d5f32135834fc5f02bd12e8b14f0857cf14d4475ad03bb"},
-    {file = "lief-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:70b53498390e8b95d878598c95bd068f5c86cab415c3869538fbce4cee36a9cc"},
-    {file = "lief-0.14.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:c49d34c9140a4b77046137ceeeb872f26262447f514ccbf0cc985a91e59e7f69"},
-    {file = "lief-0.14.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:46808f2ec6903d8a4a4a4975d664e70c64ca11691bacb391a51029a8cb941e92"},
-    {file = "lief-0.14.0-cp312-cp312-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:4e6ca44bc9d0d314ac73148c64e4f9182c950a2f2024ab9d3d7100635d46261a"},
-    {file = "lief-0.14.0-cp312-cp312-win32.whl", hash = "sha256:17e2809fa52e377d1a5045dbbbdea8bebbaad7f672d6c133287388e7e9942b64"},
-    {file = "lief-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:5713e27ba7bbe7c8c503354f3555a33e69d5236a02dd34d162156cc85a9b88b5"},
-    {file = "lief-0.14.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9998bd60d332b50f72fb71d22316b227f9fdbb301c953e8aa003822a80a6ed0a"},
-    {file = "lief-0.14.0-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:fe783a180d63aa3ae19c5f58dc76afc179f40249c4c77d9f70bc557255b4051b"},
-    {file = "lief-0.14.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:28e847e8410b9101f49af0ae9d06e7cb2d0db64c47442ac4c79abf1b15b2c108"},
-    {file = "lief-0.14.0-cp38-cp38-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:4a44d5bd2462c9db68227ed9193243c412ce6153fe6a8e53782ff4210e4606ab"},
-    {file = "lief-0.14.0-cp38-cp38-win32.whl", hash = "sha256:0a0754079d595c9e3ceffed9e32d309ed139b1433fad9ad37aaa35e6a8e67d70"},
-    {file = "lief-0.14.0-cp38-cp38-win_amd64.whl", hash = "sha256:bc8647f050728c09645666765de6dcbc681df7b0b6bdcfb4cdbbb96a523d2eaa"},
-    {file = "lief-0.14.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7f89b8e3cc6aa01f50a8ed58d5aea89f6d767df7951fd050659e9617c1b4eb45"},
-    {file = "lief-0.14.0-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:110705c186f2ddc13fc2fad0dc9d501742d785b934103fdf56e86a86bcbcac1d"},
-    {file = "lief-0.14.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0ba07f12c00950554d29495c3aef3740c44243d1c0d80a3f8dadf64c456a32e7"},
-    {file = "lief-0.14.0-cp39-cp39-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:f237042467f41bf0e64b051e780865f9aef958ddec1a358317cc259da2ec2a16"},
-    {file = "lief-0.14.0-cp39-cp39-win32.whl", hash = "sha256:75c7daefe56ba91ad4fc0a5e6573ca3c79dea2e938787b285b31ac0c25c5e5c3"},
-    {file = "lief-0.14.0-cp39-cp39-win_amd64.whl", hash = "sha256:583d37400c85dc80299db873d380c0901995ae03606f7de50fd3d0538e7a7860"},
+    {file = "lief-0.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a9a94882f9af110fb01b4558a58941d2352b9a4ae3fef15570a3fab921ff462"},
+    {file = "lief-0.14.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:bcc06f24f64fa6f20372d625ce60c40a7a6f669e11bdd02c2f0b8c5c6d09a5ee"},
+    {file = "lief-0.14.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d22f804eee7f1b4a4b37e7a3d35e2003c4c054f3450d40389e54c8ac9fc2a5db"},
+    {file = "lief-0.14.1-cp310-cp310-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:26134815adecfd7f15dfbdf12cc64df25bcf3d0db917cf115fc3b296d09be496"},
+    {file = "lief-0.14.1-cp310-cp310-win32.whl", hash = "sha256:6ca0220189698599df30b8044f43fb1fc7ba919fb9ef6047c892f9faee16393a"},
+    {file = "lief-0.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:c321234b50997c217107c09e69f53518c37fac637f8735c968c258dd4c748fb2"},
+    {file = "lief-0.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3ca365c704c6b6b1ce631b92fea2eddaf93d66c897a0ec4ab51e9ab9e3345920"},
+    {file = "lief-0.14.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:1f3c40eadff07a4c8fa74f1e268f9fa70b68f39b6795a00cd82160ca6782d5c3"},
+    {file = "lief-0.14.1-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:c202ed13b641db2e1f8a24743fb0c85595b32ea92cc3c517d3f7a9977e16dcb4"},
+    {file = "lief-0.14.1-cp311-cp311-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:fd481bfdfef04e8be4d200bca771d0d9394d9146c6cd403f9e58c80c4196a24e"},
+    {file = "lief-0.14.1-cp311-cp311-win32.whl", hash = "sha256:473e9a37beef8db8bab1a777271aa49cce44dfe35af65cb8fad576377518c0bd"},
+    {file = "lief-0.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:24f687244e14d4a8307430babc5c712a1dd4e519172886ad4aeb9825f88f7569"},
+    {file = "lief-0.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6df40e3750b8b26f88a6b28ac01db7338cdb6158f28363c755bf36452ce20d28"},
+    {file = "lief-0.14.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:e7f7a55db2fcf269569f9e9fa5ea752620396de17bd9d29fc8b29e176975ecdb"},
+    {file = "lief-0.14.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:50795b51884b76a78c481d6d069d992561c217180bd81cf12554180389eff0a3"},
+    {file = "lief-0.14.1-cp312-cp312-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:497b88f9c9aaae999766ba188744ee35c5f38b4b64016f7dbb7037e9bf325382"},
+    {file = "lief-0.14.1-cp312-cp312-win32.whl", hash = "sha256:08bad88083f696915f8dcda4042a3bfc514e17462924ec8984085838b2261921"},
+    {file = "lief-0.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:e131d6158a085f8a72124136816fefc29405c725cd3695ce22a904e471f0f815"},
+    {file = "lief-0.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:df650fa05ca131e4dfeb42c77985e1eb239730af9944bc0aadb1dfac8576e0e8"},
+    {file = "lief-0.14.1-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:b4e76eeb48ca2925c6ca6034d408582615f2faa855f9bb11482e7acbdecc4803"},
+    {file = "lief-0.14.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:016e4fac91303466024154dd3c4b599e8b7c52882f72038b62a2be386d98c8f9"},
+    {file = "lief-0.14.1-cp38-cp38-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:9a5c7732a3ce53b306c8180ab64fdfb36d8cd9df91aedd9e2b4dad9faf47492b"},
+    {file = "lief-0.14.1-cp38-cp38-win32.whl", hash = "sha256:7030c22a4446ea2ac673fd50128e9c639121c0a4dae11ca1cd8cc20d62d26e7e"},
+    {file = "lief-0.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a35ceeee74bb9bb4c7171f4bca814576a3aa6dec16a0a9469e5743db0a9ba0c"},
+    {file = "lief-0.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:abb15e4de34e70661fd35e87e2634abf0ae57a8c8ac78d02ad4259f5a5817e26"},
+    {file = "lief-0.14.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:33d062340c709c1a33539d221ea3cb764cbb8d7c9ee8aae28bf9797bc8715a0b"},
+    {file = "lief-0.14.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:66deb1b26de43acb2fd0b2fc5e6be70093eaaa93797332cc4613e163164c77e7"},
+    {file = "lief-0.14.1-cp39-cp39-manylinux_2_28_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:c1c15bd3e5b15da6dcc0ba75d5549f15bfbf9214c0d8e3938f85877a40c352d9"},
+    {file = "lief-0.14.1-cp39-cp39-win32.whl", hash = "sha256:ebcbe4eadd33d8cf2c6015f44d6c9b72f81388af745938e633c4bb90262b2036"},
+    {file = "lief-0.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:2db3eb282a35daf51f89c6509226668a08fb6a6d1f507dd549dd9f077585db11"},
 ]
 
 [[package]]
@@ -581,23 +581,23 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyinstaller"
-version = "6.3.0"
+version = "6.4.0"
 description = "PyInstaller bundles a Python application and all its dependencies into a single package."
 optional = false
 python-versions = "<3.13,>=3.8"
 files = [
-    {file = "pyinstaller-6.3.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:75a6f2a6f835a2e6e0899d10e60c10caf5defd25aced38b1dd48fbbabc89de07"},
-    {file = "pyinstaller-6.3.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:de25beb176f73a944758553caacec46cc665bf3910ad8a174706d79cf6e95340"},
-    {file = "pyinstaller-6.3.0-py3-none-manylinux2014_i686.whl", hash = "sha256:e436fcc0ea87c3f132baac916d508c24c84a8f6d8a06c3154fbc753f169b76c7"},
-    {file = "pyinstaller-6.3.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:b721d793a33b6d9946c7dd95d3ea7589c0424b51cf1b9fe580f03c544f1336b2"},
-    {file = "pyinstaller-6.3.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:96c37a1ee5b2fd5bb25c098ef510661d6d17b6515d0b86d8fc93727dd2475ba3"},
-    {file = "pyinstaller-6.3.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:abe91106a3bbccc3f3a27af4325676ecdb6f46cb842ac663625002a870fc503b"},
-    {file = "pyinstaller-6.3.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:41c937fe8f07ae02009b3b5a96ac3eb0800a4f8a97af142d4100060fe2135bb9"},
-    {file = "pyinstaller-6.3.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:886b3b995b674905a20ad5b720b47cc395897d7b391117831027a4c8c5d67a58"},
-    {file = "pyinstaller-6.3.0-py3-none-win32.whl", hash = "sha256:0597fb04337695e5cc5250253e0655530bf14f264b7a5b7d219cc65f6889c4bd"},
-    {file = "pyinstaller-6.3.0-py3-none-win_amd64.whl", hash = "sha256:156b32ba943e0090bcc68e40ae1cb68fd92b7f1ab6fe0bdf8faf3d3cfc4e12dd"},
-    {file = "pyinstaller-6.3.0-py3-none-win_arm64.whl", hash = "sha256:1eadbd1fae84e2e6c678d8b4ed6a232ec5c8fe3a839aea5a3071c4c0282f98cc"},
-    {file = "pyinstaller-6.3.0.tar.gz", hash = "sha256:914d4c96cc99472e37ac552fdd82fbbe09e67bb592d0717fcffaa99ea74273df"},
+    {file = "pyinstaller-6.4.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:a2e63fa71784f290bbf79b31b60a27c45b17a18b8c7f910757f9474e0c12c95d"},
+    {file = "pyinstaller-6.4.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:3127724d1841f785a9916d7b4cfd9595f359925e9ce7d137a16db8c29ca8453b"},
+    {file = "pyinstaller-6.4.0-py3-none-manylinux2014_i686.whl", hash = "sha256:a37f83850cb150ad1e00fe92acecc4d39b8e10162a1850a5836a05fcb2daa870"},
+    {file = "pyinstaller-6.4.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:28b98fa3c74602bdc4c5a7698e907f31e714cc40a13f6358082bcbc74ddab35c"},
+    {file = "pyinstaller-6.4.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:3ae62cf8858ec4dc54df6fa03d29bc78297e3c87caf532887eae8c3893be0789"},
+    {file = "pyinstaller-6.4.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e3e1e6922a4260dcacf6f5655b0ca857451e05ac502d01642935d0f2873ad3c7"},
+    {file = "pyinstaller-6.4.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:78fb66ca753ef8becdf059eaa1e764d384cacb8c2ec76800126f8c9ef6d19a50"},
+    {file = "pyinstaller-6.4.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:e07cff584600647af7dc279dd04c60cd1b4b1b41947b0753f8fcf1969300a583"},
+    {file = "pyinstaller-6.4.0-py3-none-win32.whl", hash = "sha256:c7bc0fbea8a9010484cfa7d3856416003af73271f03ca3da4bc0eaf14680ad17"},
+    {file = "pyinstaller-6.4.0-py3-none-win_amd64.whl", hash = "sha256:ec8a08c983e3febb0247893cd9bd59f55b6767a1f649cb41a0a129b8f04ff2cb"},
+    {file = "pyinstaller-6.4.0-py3-none-win_arm64.whl", hash = "sha256:11e6da6a6e441379352ee460a8880f2633dac91dac0f5a9eeff5d449d459b046"},
+    {file = "pyinstaller-6.4.0.tar.gz", hash = "sha256:1bf608ed947b58614711275a7ff169289b32560dc97ec748ebd5fa8bdec80649"},
 ]
 
 [package.dependencies]
@@ -605,7 +605,7 @@ altgraph = "*"
 macholib = {version = ">=1.8", markers = "sys_platform == \"darwin\""}
 packaging = ">=22.0"
 pefile = {version = ">=2022.5.30", markers = "sys_platform == \"win32\""}
-pyinstaller-hooks-contrib = ">=2021.4"
+pyinstaller-hooks-contrib = ">=2024.0"
 pywin32-ctypes = {version = ">=0.2.1", markers = "sys_platform == \"win32\""}
 setuptools = ">=42.0.0"
 
@@ -615,13 +615,13 @@ hook-testing = ["execnet (>=1.5.0)", "psutil", "pytest (>=2.7.3)"]
 
 [[package]]
 name = "pyinstaller-hooks-contrib"
-version = "2024.0"
+version = "2024.1"
 description = "Community maintained hooks for PyInstaller"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyinstaller-hooks-contrib-2024.0.tar.gz", hash = "sha256:a7118c1a5c9788595e5c43ad058a7a5b7b6d59e1eceb42362f6ec1f0b61986b0"},
-    {file = "pyinstaller_hooks_contrib-2024.0-py2.py3-none-any.whl", hash = "sha256:469b5690df53223e2e8abffb2e44d6ee596e7d79d4b1eed9465123b67439875a"},
+    {file = "pyinstaller-hooks-contrib-2024.1.tar.gz", hash = "sha256:51a51ea9e1ae6bd5ffa7ec45eba7579624bf4f2472ff56dba0edc186f6ed46a6"},
+    {file = "pyinstaller_hooks_contrib-2024.1-py2.py3-none-any.whl", hash = "sha256:131494f9cfce190aaa66ed82e82c78b2723d1720ce64d012fbaf938f4ab01d35"},
 ]
 
 [package.dependencies]
@@ -704,6 +704,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -758,18 +759,18 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "setuptools"
-version = "69.0.3"
+version = "69.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.0.3-py3-none-any.whl", hash = "sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05"},
-    {file = "setuptools-69.0.3.tar.gz", hash = "sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78"},
+    {file = "setuptools-69.1.0-py3-none-any.whl", hash = "sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6"},
+    {file = "setuptools-69.1.0.tar.gz", hash = "sha256:850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,14 +51,23 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-addopts = "--verbose --cov-append --cov-report term --cov blint"
-
-[tool.flake8]
-ignore = "E203, E266, E501, W503, W605"
-max-line-length = 80
-max-complexity = 18
-select = "B,C,E,F,W,T4,B9"
+#addopts = "--verbose --cov-append --cov-report term --cov blint"
 
 [tool.pylint]
 generated-members = ["lief"]
-disable = ["broad-exception-caught", "too-many-branches", "too-many-statements", "too-many-nested-blocks", "too-many-locals", "missing-function-docstring", "too-many-lines", "missing-module-docstring"]
+ignore-paths = ["blint/cyclonedx/*", "blint/checks.py"]
+ignore-long-lines = "[r|f]\""
+disable = ["missing-module-docstring", "logging-fstring-interpolation"]
+
+[tool.pylint.format]
+max-line-length = 80
+
+[tool.pylint.design]
+max-args = 6
+max-nested-blocks = 6
+
+[tool.pylint.logging]
+logging-format-style = "new"
+
+[tool.pylint.messages_control]
+disable = "W0718, C0103, C0209, C0302, W0613, E1205"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 name = "blint"
 version = "2.0.0"
 description = "Linter and SBOM generator for binary files."
-authors = ["Prabhu Subramanian <prabhu@appthreat.com>"]
-maintainers= ["Prabhu Subramanian <prabhu@appthreat.com>", "Caroline Russell <caroline@appthreat.dev>"]
+authors = ["Prabhu Subramanian <prabhu@appthreat.com>", "Caroline Russell <caroline@appthreat.dev>"]
 license = "Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/OWASP-dep-scan/blint"
@@ -44,30 +43,26 @@ pytest-cov = "^4.0.0"
 pyinstaller = "^6.3.0"
 
 [tool.black]
-line-length = 80
+line-length = 99
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-#addopts = "--verbose --cov-append --cov-report term --cov blint"
+addopts = "--verbose --cov-append --cov-report term --cov blint"
 
 [tool.pylint]
 generated-members = ["lief"]
-ignore-paths = ["blint/cyclonedx/*", "blint/checks.py"]
+ignore-paths = ["blint/cyclonedx/*"]
+# Let's not fuss about long strings
 ignore-long-lines = "[r|f]\""
 disable = ["missing-module-docstring", "logging-fstring-interpolation"]
 
 [tool.pylint.format]
-max-line-length = 80
+max-line-length = 99
 
 [tool.pylint.design]
 max-args = 6
 max-nested-blocks = 6
 
-[tool.pylint.logging]
-logging-format-style = "new"
-
-[tool.pylint.messages_control]
-disable = "W0718, C0103, C0209, C0302, W0613, E1205"

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,25 +1,31 @@
 import json
 from pathlib import Path
 
-from blint.analysis import run_checks, run_review
+from blint.analysis import ReviewRunner, run_checks
 
 
 def test_gobinary():
     test_go_file = Path(__file__).parent / "data" / "ngrok-elf.json"
+    # test_go_file = Path('C:\\Users\\user\\PycharmProjects\\blint\\tests\\data\\ngrok-elf.json')
     with open(test_go_file) as fp:
         metadata = json.load(fp)
-        results = run_checks(test_go_file.name, metadata)
-        assert results
-        assert results[0]["id"] == "CHECK_PIE"
-        results = run_review(test_go_file.name, metadata)
-        assert results
+    results = run_checks(test_go_file.name, metadata)
+    assert results
+    assert results[0]["id"] == "CHECK_PIE"
+    reviewer = ReviewRunner()
+    reviewer.run_review(metadata)
+    results = reviewer.process_review(test_go_file, test_go_file.name)
+    assert results
 
 
 def test_genericbinary():
     test_gnu_file = Path(__file__).parent / "data" / "netstat-elf.json"
+    # test_gnu_file = Path('data/netstat-elf.json')
     with open(test_gnu_file) as fp:
         metadata = json.load(fp)
-        results = run_checks(test_gnu_file.name, metadata)
-        assert not results
-        results = run_review(test_gnu_file.name, metadata)
-        assert not results
+    results = run_checks(test_gnu_file.name, metadata)
+    assert not results
+    reviewer = ReviewRunner()
+    reviewer.run_review(metadata)
+    results = reviewer.process_review('data/netstat-elf.json', test_gnu_file.name)
+    assert not results


### PR DESCRIPTION
### Refactoring, optimizing, linting
- I have refactored to make the code easier to maintain and understand, as well as to reduce unnecessary resource use . 
- Where possible and practical, I have extracted sections of very long functions out to make the code more modular.
- I have removed all but "missing-module-docstring" and "logging-fstring-interpolation" from our pylint disable list. The refactoring resolved almost everything else.
- I increased the max line length to 99 since 80 was decreasing readability rather than increasing it.
- What the refactoring did not resolve, or where there is a good reason for ignoring the pylint warning, I have addressed with pylint disable flags.

### Minor bugfix
I improved the logic for checking dll characteristics so that we report all missing characteristics rather than only the first one found.

### Lief issues
This PR also addresses remaining issues with the lief upgrade from 0.12.3 -> 0.14.0 (and upgrades to 0.14.1). These issues pertain to  lief no longer raising exceptions but returning an instance of a lief exception object so that we are unable to know whether there has been a failure unless we check type. We also won't be able to rely on simple if exists statements since these will evaluate to True when lief has actually returned an exception object.

My attempt to handle this change consists of:
- checking type where a lief exception object is going to result in an obvious Attribute error. E.g. we get binary.a and then later expect to be able to do binary.a.b.
- Removing lief.lief_error instance objects from our metadata at the end of the scan.

Given how extensively we have previously been able to rely on checking for truthiness and on lief exceptions being raised, it is probable there may be additional changes that need to be made that I have not anticipated.