### PR TITLE
Use individual arguments rather than passing the cli args for depscan compatibility.

### DIFF
--- a/blint/cli.py
+++ b/blint/cli.py
@@ -173,7 +173,9 @@ def main():
     else:
         files = gen_file_list(src_dirs)
         analyzer = AnalysisRunner()
-        findings, reviews, fuzzables = analyzer.start(args, files, reports_dir)
+        findings, reviews, fuzzables = analyzer.start(
+            files, reports_dir, args.no_reviews, args.suggest_fuzzable
+        )
         report(src_dirs, reports_dir, findings, reviews, files, fuzzables)
 
         if os.getenv("CI") and not args.noerror:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blint"
-version = "2.0.0"
+version = "2.0.0-beta.2"
 description = "Linter and SBOM generator for binary files."
 authors = ["Prabhu Subramanian <prabhu@appthreat.com>", "Caroline Russell <caroline@appthreat.dev>"]
 license = "Apache-2.0"
@@ -65,4 +65,3 @@ max-line-length = 99
 [tool.pylint.design]
 max-args = 6
 max-nested-blocks = 6
-


### PR DESCRIPTION
AnalysisRunner.start() now accepts args.no_reviews and args.suggest_fuzzable as separate optional arguments rather than passing the cli args together.