### PR TITLE
Updated analysis.py to generate reports only upon findings

### DIFF
--- a/blint/analysis.py
+++ b/blint/analysis.py
@@ -343,9 +343,10 @@ def report(src_dir, reports_dir, findings, reviews, files, fuzzables):
     if not findings and not reviews:
         LOG.info(f":white_heavy_check_mark: No issues found in {src_dir}!")
     # Try console output as html
-    html_file = Path(reports_dir) / "blint-output.html"
-    console.save_html(html_file, theme=MONOKAI)
-    LOG.info(f"HTML report written to {html_file}")
+    if findings or reviews:
+        html_file = Path(reports_dir) / "blint-output.html"
+        console.save_html(html_file, theme=MONOKAI)
+        LOG.info(f"HTML report written to {html_file}")
 
 
 class AnalysisRunner:


### PR DESCRIPTION
`if findings or reviews:` is added to validate the presence of any findings and/or reviews before generating a HTML report. This ensures that reports are generated only for scans with findings.