### PR TITLE
Use alias while dumping json

### DIFF
--- a/blint/config.py
+++ b/blint/config.py
@@ -33,6 +33,7 @@ ignore_files = [
     ".gz",
     ".tar",
     ".tar.gz",
+    ".tar.xz",
     ".tar",
     ".log",
     ".tmp",
@@ -71,6 +72,7 @@ ignore_files = [
     ".nib",
     ".nupkg",
     ".pak",
+    ".xml"
 ]
 strings_allowlist = {
     "()",

--- a/blint/sbom.py
+++ b/blint/sbom.py
@@ -179,6 +179,7 @@ def create_sbom(
                 exclude_none=True,
                 exclude_defaults=True,
                 warnings=False,
+                by_alias=True
             )
         )
         LOG.debug(f"SBOM file generated successfully at {output_file}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blint"
-version = "2.0.3"
+version = "2.0.4"
 description = "Linter and SBOM generator for binary files."
 authors = ["Prabhu Subramanian <prabhu@appthreat.com>", "Caroline Russell <caroline@appthreat.dev>"]
 license = "MIT"


### PR DESCRIPTION
jsonschema validation was failing without this

```
[
  {
    instancePath: '/metadata/component',
    schemaPath: '#/additionalProperties',
    keyword: 'additionalProperties',
    params: { additionalProperty: 'bom_ref' },
    message: 'must NOT have additional properties'
  }
]
```

```
[
  {
    instancePath: '/dependencies',
    schemaPath: '#/properties/dependencies/uniqueItems',
    keyword: 'uniqueItems',
    params: { i: 97, j: 48 },
    message: 'must NOT have duplicate items (items ## 48 and 97 are identical)'
  }
]
```
