### PR TITLE
sbom: add stdout json output additionally to file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ options:
   -h, --help            show this help message and exit
   -i SRC_DIR_IMAGE [SRC_DIR_IMAGE ...], --src SRC_DIR_IMAGE [SRC_DIR_IMAGE ...]
                         Source directories, container images or binary files. Defaults to current directory.
-  -o SBOM_OUTPUT, --output-file SBOM_OUTPUT
-                        SBOM output file. Defaults to bom.json in current directory.
+  -o SBOM_OUTPUT, --output SBOM_OUTPUT
+                        SBOM output to file or stdout. Use json for stdout, file name or file path for file. Defaults to bom.json file in current directory.
   --deep                Enable deep mode to collect more used symbols and modules aggressively. Slow
                         operation.
 ```
@@ -105,6 +105,10 @@ blint sbom -i /path/to/apk -o bom.json
 ```
 
 ```shell
+blint sbom -i /path/to/apk -o json
+```
+
+```shell
 blint sbom -i /directory/with/apk/aab -o bom.json
 ```
 
@@ -122,6 +126,10 @@ The following binaries are supported:
 
 ```shell
 blint sbom -i /path/to/go-binaries -o bom.json --deep
+```
+
+```shell
+blint sbom -i /path/to/go-binaries -o json --deep
 ```
 
 For all other binaries, the symbols will be collected and represented as properties with `internal` prefixes for the parent component. Child components and dependencies would be missing.

--- a/README.md
+++ b/README.md
@@ -68,16 +68,21 @@ sub-commands:
 ### SBOM sub-command
 
 ```shell
-usage: blint sbom [-h] [-i SRC_DIR_IMAGE [SRC_DIR_IMAGE ...]] [-o SBOM_OUTPUT] [--deep]
+usage: blint sbom [-h] [-i SRC_DIR_IMAGE [SRC_DIR_IMAGE ...]] [-o SBOM_OUTPUT]
+                  [--deep] [--no-banner]
 
 options:
   -h, --help            show this help message and exit
   -i SRC_DIR_IMAGE [SRC_DIR_IMAGE ...], --src SRC_DIR_IMAGE [SRC_DIR_IMAGE ...]
-                        Source directories, container images or binary files. Defaults to current directory.
-  -o SBOM_OUTPUT, --output SBOM_OUTPUT
-                        SBOM output to file or stdout. Use json for stdout, file name or file path for file. Defaults to bom.json file in current directory.
-  --deep                Enable deep mode to collect more used symbols and modules aggressively. Slow
-                        operation.
+                        Source directories, container images or binary files.
+                        Defaults to current directory.
+  -o SBOM_OUTPUT, --output-file SBOM_OUTPUT
+                        SBOM output stdout or file. Use json for stdout or
+                        filename for file. Defaults to bom.json file in
+                        current directory.
+  --deep                Enable deep mode to collect more used symbols and
+                        modules aggressively. Slow operation.
+  --no-banner           Do not display banner.
 ```
 
 To test any binary, including default commands

--- a/blint/cli.py
+++ b/blint/cli.py
@@ -104,6 +104,13 @@ def build_args():
         help="Enable deep mode to collect more used symbols and modules "
              "aggressively. Slow operation.",
     )
+    sbom_parser.add_argument(
+        "--no-banner",
+        action="store_true",
+        default=False,
+        dest="no_banner",
+        help="Do not display banner.",
+    )
     return parser.parse_args()
 
 

--- a/blint/cli.py
+++ b/blint/cli.py
@@ -92,9 +92,9 @@ def build_args():
     )
     sbom_parser.add_argument(
         "-o",
-        "--output-file",
+        "--output",
         dest="sbom_output",
-        help="SBOM output file. Defaults to bom.json in current directory.",
+        help="SBOM output stdout or file. Use ""json"" for stdout or filename for file. Defaults to bom.json file in current directory.",
     )
     sbom_parser.add_argument(
         "--deep",

--- a/blint/cli.py
+++ b/blint/cli.py
@@ -92,7 +92,7 @@ def build_args():
     )
     sbom_parser.add_argument(
         "-o",
-        "--output",
+        "--output-file",
         dest="sbom_output",
         help="SBOM output stdout or file. Use ""json"" for stdout or filename for file. Defaults to bom.json file in current directory.",
     )

--- a/blint/sbom.py
+++ b/blint/sbom.py
@@ -4,6 +4,7 @@ import codecs
 import os
 import urllib.parse
 import uuid
+import sys
 from datetime import datetime
 from typing import Any, Dict
 
@@ -192,7 +193,7 @@ def create_sbom(
         return True
     else:
         # Write the JSON output directly to stdout
-        LOG(sbom_content)
+        sys.stdout.write(sbom_content)
         return True
 
 

--- a/blint/sbom.py
+++ b/blint/sbom.py
@@ -4,7 +4,6 @@ import codecs
 import os
 import urllib.parse
 import uuid
-import sys
 from datetime import datetime
 from typing import Any, Dict
 
@@ -193,8 +192,7 @@ def create_sbom(
         return True
     else:
         # Write the JSON output directly to stdout
-        sys.stdout.write(sbom_content)
-        LOG.debug(f"SBOM json output printed successfully to stdout")
+        LOG.info(sbom_content)
         return True
 
 

--- a/blint/sbom.py
+++ b/blint/sbom.py
@@ -28,7 +28,6 @@ from blint.cyclonedx.spec import (
     Type,
 )
 from blint.logger import LOG
-from blint.logger import console
 from blint.utils import camel_to_snake, create_component_evidence, find_android_files, gen_file_list, get_version
 
 
@@ -193,7 +192,7 @@ def create_sbom(
         return True
     else:
         # Write the JSON output directly to stdout
-        console(sbom_content)
+        LOG(sbom_content)
         return True
 
 

--- a/blint/sbom.py
+++ b/blint/sbom.py
@@ -28,6 +28,7 @@ from blint.cyclonedx.spec import (
     Type,
 )
 from blint.logger import LOG
+from blint.logger import console
 from blint.utils import camel_to_snake, create_component_evidence, find_android_files, gen_file_list, get_version
 
 
@@ -192,7 +193,7 @@ def create_sbom(
         return True
     else:
         # Write the JSON output directly to stdout
-        LOG.info(sbom_content)
+        console(sbom_content)
         return True
 
 


### PR DESCRIPTION
Currently the SBOM generation requires a file where the SBOM is stored in. This PR changes the output slightly to allow json console output with or without banner to stdout when using json as a value instead of the filename.