### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ sbom command generates CycloneDX json.
 
 ## References
 
-- [lief examples](https://github.com/lief-project/LIEF/tree/master/examples/python)
+- [lief examples](https://github.com/lief-project/LIEF/tree/master/examples)
 - [checksec](https://github.com/Wenzel/checksec.py)
 
 ## Discord support


### PR DESCRIPTION
LIEF Python examples gives a 404 - page not found error. Better to link to parent examples directory instead