### PR TITLE
JSON dumps error due to bytes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,7 @@ name: Build Linux Binaries
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -1,6 +1,8 @@
 name: Python matrix CI
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -3,6 +3,7 @@ name: Build Windows Binaries
 on:
   push:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   Blint-Build:

--- a/blint/analysis.py
+++ b/blint/analysis.py
@@ -1,6 +1,5 @@
 import contextlib
 import importlib  # noqa
-import orjson
 import os
 import re
 import sys
@@ -10,12 +9,13 @@ from datetime import datetime
 from itertools import islice
 from pathlib import Path
 
+import orjson
 import yaml
 from rich.progress import Progress
 from rich.terminal_theme import MONOKAI
 
 from blint.binary import parse
-from blint.checks import (check_nx, check_pie,  # noqa, pylint: disable=unused-import
+from blint.checks import (check_nx, check_pie,
                           check_relro, check_canary, check_rpath,
                           check_virtual_size, check_authenticode,
                           check_dll_characteristics, check_codesign,
@@ -327,20 +327,23 @@ def report(src_dir, reports_dir, findings, reviews, files, fuzzables):
         print_findings_table(findings, files)
         findings_file = Path(reports_dir) / "findings.json"
         LOG.info(f"Findings written to {findings_file}")
-        output = orjson.dumps({**common_metadata, "findings": findings}).decode("utf-8", "ignore")
+        output = orjson.dumps({**common_metadata, "findings": findings}, default=json_serializer).decode("utf-8",
+                                                                                                         "ignore")
         with open(findings_file, mode="w", encoding="utf-8") as ffp:
             ffp.write(output)
     if reviews:
         print_reviews_table(reviews, files)
         reviews_file = Path(reports_dir) / "reviews.json"
         LOG.info(f"Review written to {reviews_file}")
-        output = orjson.dumps({**common_metadata, "reviews": reviews}).decode("utf-8", "ignore")
+        output = orjson.dumps({**common_metadata, "reviews": reviews}, default=json_serializer).decode("utf-8",
+                                                                                                       "ignore")
         with open(reviews_file, mode="w", encoding="utf-8") as rfp:
             rfp.write(output)
     if fuzzables:
         fuzzables_file = Path(reports_dir) / "fuzzables.json"
         LOG.info(f"Fuzzables data written to {fuzzables_file}")
-        output = orjson.dumps({**common_metadata, "fuzzables": fuzzables}).decode("utf-8", "ignore")
+        output = orjson.dumps({**common_metadata, "fuzzables": fuzzables}, default=json_serializer).decode("utf-8",
+                                                                                                           "ignore")
         with open(fuzzables_file, mode="w", encoding="utf-8") as rfp:
             rfp.write(output)
     else:
@@ -411,7 +414,7 @@ class AnalysisRunner:
         metadata_file = (Path(reports_dir) / f"{os.path.basename(exe_name)}"
                                              f"-metadata.json")
         LOG.debug(f"Metadata written to {metadata_file}")
-        output = orjson.dumps(metadata).decode("utf-8", "ignore")
+        output = orjson.dumps(metadata, default=json_serializer).decode("utf-8", "ignore")
         with open(metadata_file, mode="w", encoding="utf-8") as ffp:
             ffp.write(output)
         self.progress.update(
@@ -639,8 +642,7 @@ class ReviewRunner:
                     if found_pattern[apattern] > EVIDENCE_LIMIT or found_cid[cid] > EVIDENCE_LIMIT:
                         continue
                     for afun in functions_list:
-                        if ((apattern.lower() in afun.lower()) and not
-                                found_function.get(afun.lower())):
+                        if apattern.lower() in afun.lower() and not found_function.get(afun.lower()):
                             result = {"pattern": apattern, "function": afun, }
                             results[cid].append(result)
                             found_cid[cid] += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ build-backend = "poetry.core.masonry.api"
 addopts = "--verbose --cov-append --cov-report term --cov blint"
 
 [tool.pylint]
-generated-members = ["lief"]
+generated-members = ["lief", "orjson"]
 ignore-paths = ["blint/cyclonedx/*"]
 # Let's not fuss about long strings
 ignore-long-lines = "[r|f]\""


### PR DESCRIPTION
@timmyteo could you kindly test this branch?

```
Traceback (most recent call last):
  File "blint\cli.py", line 204, in <module>
    main()
  File "blint\cli.py", line 192, in main
    findings, reviews, fuzzables = analyzer.start(
                                   ^^^^^^^^^^^^^^^
  File "blint\analysis.py", line 393, in start
    self._process_files(f, reports_dir, no_reviews, suggest_fuzzables)
  File "blint\analysis.py", line 414, in _process_files
    output = orjson.dumps(metadata).decode("utf-8", "ignore")
             ^^^^^^^^^^^^^^^^^^^^^^
TypeError: Type is not JSON serializable: bytes
[1680] Failed to execute script 'cli' due to unhandled exception!
```

https://github.com/owasp-dep-scan/blint/actions/runs/8818460640/job/24207282174#step:5:19