### PR TITLE
Added check for presence of .data section in PE binary for go buildinfo func

### DIFF
--- a/blint/binary.py
+++ b/blint/binary.py
@@ -1010,14 +1010,15 @@ def parse_go_buildinfo(
     elif isinstance(parsed_obj, lief.PE.Binary):
         # For PE binaries look for .data section
         s: lief.PE.Section = parsed_obj.get_section(".data")
-        build_info_str = (
-            codecs.decode(
-                s.content.tobytes()[: int(s.size / 32)], encoding="ascii", errors="replace"
+        if s:
+            build_info_str = (
+                codecs.decode(
+                    s.content.tobytes()[: int(s.size / 32)], encoding="ascii", errors="replace"
+                )
+                .replace("\0", "")
+                .replace("\uFFFD", "")
+                .replace("\t", " ")
             )
-            .replace("\0", "")
-            .replace("\uFFFD", "")
-            .replace("\t", " ")
-        )
     lines = build_info_str.split("\n")
     for line in lines:
         if line.startswith("Go buildinf:"):

--- a/blint/binary.py
+++ b/blint/binary.py
@@ -1010,7 +1010,7 @@ def parse_go_buildinfo(
     elif isinstance(parsed_obj, lief.PE.Binary):
         # For PE binaries look for .data section
         s: lief.PE.Section = parsed_obj.get_section(".data")
-        if s:
+        if s and not isinstance(s, lief.lief_errors):
             build_info_str = (
                 codecs.decode(
                     s.content.tobytes()[: int(s.size / 32)], encoding="ascii", errors="replace"


### PR DESCRIPTION
This patch adds a check whether a `.data` section is present, and if that's the case, then tries to decode the section. Currently with latest commit in the `main` branch of `blint` an error will be displayed to the user in case there is no `.data` section for a PE file within the `parse_go_buildinfo()` function:

```py
ERROR    Caught <class 'AttributeError'>: 'NoneType' object has no attribute 'content' while parsing                                                                                   
                    Samples/13337328933/64156f9ca51951a9bf91b5b74073d31c16873ca60492c25895c1f0f074787345.                                                                                         
                    Traceback (most recent call last):                                                                                                                                            
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 741, in parse                                                                                 
                        metadata = add_pe_metadata(exe_file, metadata, parsed_obj)                                                                                                                
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1124, in add_pe_metadata                                                                      
                        metadata["go_dependencies"], metadata["go_formulation"] = parse_go_buildinfo(parsed_obj)                                                                                  
                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                  
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1015, in parse_go_buildinfo                                                                   
                        s.content.tobytes()[: int(s.size / 32)], encoding="ascii", errors="replace"                                                                                               
                        ^^^^^^^^^                                                                                                                                                                 
                    AttributeError: 'NoneType' object has no attribute 'content'
```

Files used for testing this bug:
- https://www.virustotal.com/gui/file/64156f9ca51951a9bf91b5b74073d31c16873ca60492c25895c1f0f074787345/details
- https://www.virustotal.com/gui/file/a511ea7db84a6872a60eaebc0b9a4c5c697a6783c3775fbde47637c770d4041d/details
- https://www.virustotal.com/gui/file/38f3f6e9abc521c62f3e5ace79cff5044c1436c957df035bc7d8fe8125226fbc/details
- https://www.virustotal.com/gui/file/85d1d1ca4d5881d9b98928c2006fb0eec9655e2705fe74088e6f974a19703f0f/details
- https://www.virustotal.com/gui/file/a4b1a450cada1b25b74b8decfb92f77c64a04f0b4ec8ddaf1a3c0f962a364c0a/details

Prior to patch:
```py
           ERROR    Caught <class 'AttributeError'>: 'NoneType' object has no attribute 'content' while parsing                                                                                   
                    Samples/ingest/17483604230/3d6123dc6ffbd1a11d73229988203052809bd17617b24a034c1122c8f4983db4.                                                                                  
                    Traceback (most recent call last):                                                                                                                                            
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 741, in parse                                                                                 
                        metadata = add_pe_metadata(exe_file, metadata, parsed_obj)                                                                                                                
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1124, in add_pe_metadata                                                                      
                        metadata["go_dependencies"], metadata["go_formulation"] = parse_go_buildinfo(parsed_obj)                                                                                  
                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                  
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1015, in parse_go_buildinfo                                                                   
                        s.content.tobytes()[: int(s.size / 32)], encoding="ascii", errors="replace"                                                                                               
                        ^^^^^^^^^                                                                                                                                                                 
                    AttributeError: 'NoneType' object has no attribute 'content'                                                                                                                  
           ERROR    Caught <class 'AttributeError'>: 'NoneType' object has no attribute 'content' while parsing                                                                                   
                    Samples/ingest/17483604230/a511ea7db84a6872a60eaebc0b9a4c5c697a6783c3775fbde47637c770d4041d.                                                                                  
                    Traceback (most recent call last):                                                                                                                                            
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 741, in parse                                                                                 
                        metadata = add_pe_metadata(exe_file, metadata, parsed_obj)                                                                                                                
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1124, in add_pe_metadata                                                                      
                        metadata["go_dependencies"], metadata["go_formulation"] = parse_go_buildinfo(parsed_obj)                                                                                  
                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                  
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1015, in parse_go_buildinfo                                                                   
                        s.content.tobytes()[: int(s.size / 32)], encoding="ascii", errors="replace"                                                                                               
                        ^^^^^^^^^                                                                                                                                                                 
                    AttributeError: 'NoneType' object has no attribute 'content'                                                                                                                  
           ERROR    Caught <class 'AttributeError'>: 'NoneType' object has no attribute 'content' while parsing                                                                                   
                    Samples/ingest/17483604230/38f3f6e9abc521c62f3e5ace79cff5044c1436c957df035bc7d8fe8125226fbc.                                                                                  
                    Traceback (most recent call last):                                                                                                                                            
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 741, in parse                                                                                 
                        metadata = add_pe_metadata(exe_file, metadata, parsed_obj)                                                                                                                
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1124, in add_pe_metadata                                                                      
                        metadata["go_dependencies"], metadata["go_formulation"] = parse_go_buildinfo(parsed_obj)                                                                                  
                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                  
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1015, in parse_go_buildinfo                                                                   
                        s.content.tobytes()[: int(s.size / 32)], encoding="ascii", errors="replace"                                                                                               
                        ^^^^^^^^^                                                                                                                                                                 
                    AttributeError: 'NoneType' object has no attribute 'content'
           ERROR    Caught <class 'AttributeError'>: 'NoneType' object has no attribute 'content' while parsing                                                                                   
                    Samples/ingest/17483604230/85d1d1ca4d5881d9b98928c2006fb0eec9655e2705fe74088e6f974a19703f0f.                                                                                  
                    Traceback (most recent call last):                                                                                                                                            
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 741, in parse                                                                                 
                        metadata = add_pe_metadata(exe_file, metadata, parsed_obj)                                                                                                                
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1124, in add_pe_metadata                                                                      
                        metadata["go_dependencies"], metadata["go_formulation"] = parse_go_buildinfo(parsed_obj)                                                                                  
                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                  
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1015, in parse_go_buildinfo                                                                   
                        s.content.tobytes()[: int(s.size / 32)], encoding="ascii", errors="replace"                                                                                               
                        ^^^^^^^^^                                                                                                                                                                 
                    AttributeError: 'NoneType' object has no attribute 'content' 
           ERROR    Caught <class 'AttributeError'>: 'NoneType' object has no attribute 'content' while parsing                                                                                   
                    Samples/ingest/17483604230/a4b1a450cada1b25b74b8decfb92f77c64a04f0b4ec8ddaf1a3c0f962a364c0a.                                                                                  
                    Traceback (most recent call last):                                                                                                                                            
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 741, in parse                                                                                 
                        metadata = add_pe_metadata(exe_file, metadata, parsed_obj)                                                                                                                
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1124, in add_pe_metadata                                                                      
                        metadata["go_dependencies"], metadata["go_formulation"] = parse_go_buildinfo(parsed_obj)                                                                                  
                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                  
                      File "/home/jasper/.local/lib/python3.12/site-packages/blint/binary.py", line 1015, in parse_go_buildinfo                                                                   
                        s.content.tobytes()[: int(s.size / 32)], encoding="ascii", errors="replace"                                                                                               
                        ^^^^^^^^^                                                                                                                                                                 
                    AttributeError: 'NoneType' object has no attribute 'content' 
```


