### PR TITLE
Make blint more usable as a library

### DIFF
--- a/blint/cli.py
+++ b/blint/cli.py
@@ -95,6 +95,7 @@ def build_parser():
     sbom_parser = subparsers.add_parser(
         "sbom", help="Command to generate SBOM for supported binaries."
     )
+    sbom_parser.set_defaults(sbom_mode=True)
     sbom_parser.add_argument(
         "-i",
         "--src",

--- a/blint/cli.py
+++ b/blint/cli.py
@@ -2,11 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import argparse
-import logging
 import os
-import sys
 
-from blint.lib.analysis import AnalysisRunner, report
+from blint.lib.runners import run_default_mode, run_sbom_mode
 from blint.lib.runners import AnalysisRunner, run_default_mode, run_sbom_mode
 from blint.config import BlintOptions
 from blint.logger import LOG

--- a/blint/cli.py
+++ b/blint/cli.py
@@ -34,6 +34,14 @@ def build_parser():
         prog="blint",
         description="Binary linter and SBOM generator.",
     )
+    parser.set_defaults(
+        deep_mode=False,
+        sbom_output="",
+        stdout_mode=False,
+        exports_prefix=[],
+        src_dir_boms=[],
+        sbom_mode=False
+    )
     parser.add_argument(
         "-i",
         "--src",

--- a/blint/config.py
+++ b/blint/config.py
@@ -1,6 +1,10 @@
 # pylint: disable=too-many-lines
+import sys
+from dataclasses import dataclass, field
 import os
 import re
+from typing import List
+
 
 # Default ignore list
 ignore_directories = [
@@ -1267,6 +1271,56 @@ def get_int_from_env(name, default):
     """
     return int(get_float_from_env(name, default))
 
+
+@dataclass
+class BlintOptions:
+    """
+    A data class representing the command-line options for the blint tool.
+
+    Attributes:
+        deep_mode (bool): Flag indicating whether to perform deep analysis.
+        exports_prefix (list): Prefixes to determine exported symbols.
+        fuzzy (bool): Flag indicating whether to perform fuzzy analysis.
+        no_error (bool): Flag indicating whether to suppress error messages.
+        no_reviews (bool): Flag indicating whether to perform symbol reviews.
+        reports_dir (str): The path to the reports directory.
+        sbom_mode (bool): Flag indicating whether to perform SBOM analysis.
+        src_dir_image (list): A list of source directories.
+        sbom_output (str): The path to the output file.
+        deep_mode (bool): Flag indicating whether to perform deep analysis.
+        export_prefixes (list): Prefixes to determine exported symbols.
+        src_dir_boms (list): Directory containing pre-build and build sboms.
+    """
+    deep_mode: bool = False
+    exports_prefix: List = field(default_factory=list)
+    fuzzy: bool = False
+    no_error: bool = False
+    no_reviews: bool = False
+    reports_dir: str = ""
+    sbom_mode: bool = False
+    sbom_output: str = ""
+    sbom_output_dir: str = ""
+    src_dir_boms: List = field(default_factory=list)
+    src_dir_image: List = field(default_factory=list)
+    stdout_mode: bool = False
+    
+    def __post_init__(self):
+        if not self.src_dir_image and not (self.sbom_mode and self.src_dir_boms):
+            self.sources = [os.getcwd()]
+        if not self.reports_dir:
+            self.reports_dir = os.getcwd()
+        if self.sbom_mode:
+            if self.stdout_mode:
+                self.sbom_output = sys.stdout
+            elif not self.sbom_output:
+                self.sbom_output = os.path.join(self.reports_dir, "bom-post-build.cdx.json")
+                self.sbom_output_dir = os.path.join(self.reports_dir)
+            elif os.path.isdir(self.sbom_output):
+                self.sbom_output_dir = self.sbom_output
+                self.sbom_output = os.path.join(self.sbom_output, "bom-post-build.cdx.json")
+            else:
+                self.sbom_output_dir = os.path.dirname(self.sbom_output)
+        
 
 # PII related symbols
 PII_WORDS = (

--- a/blint/lib/analysis.py
+++ b/blint/lib/analysis.py
@@ -319,22 +319,20 @@ def print_reviews_table(reviews, files):
     console.print(table)
 
 
-def report(blint_options, findings, reviews, fuzzables):
+def report(blint_options, exe_files, findings, reviews, fuzzables):
     """Generates a report based on the analysis results.
 
     Args:
-        src_dir: The source directory.
-        reports_dir: The directory to save the reports.
+        blint_options: A BlintOptions object containing settings.
+        exe_files: A list of file names associated with the findings and reviews.
         findings: A list of dictionaries representing the findings.
         reviews: A list of dictionaries representing the reviews.
-        files: A list of file names associated with the findings and reviews.
         fuzzables: A list of fuzzable methods.
 
     """
     if not findings and not reviews:
         LOG.info(f":white_heavy_check_mark: No issues found in {blint_options.src_dir_image}!")
         return
-    
     if not os.path.exists(blint_options.reports_dir):
         os.makedirs(blint_options.reports_dir)
     run_uuid = os.environ.get("SCAN_ID", str(uuid.uuid4()))
@@ -343,10 +341,10 @@ def report(blint_options, findings, reviews, fuzzables):
         "created": f"{datetime.now():%Y-%m-%d %H:%M:%S%z}",
     }
     if findings:
-        print_findings_table(findings, blint_options.files)
+        print_findings_table(findings, exe_files)
         export_metadata(blint_options.reports_dir, {**common_metadata, "findings": findings}, "Findings")
     if reviews:
-        print_reviews_table(reviews, blint_options.files)
+        print_reviews_table(reviews, exe_files)
         export_metadata(blint_options.reports_dir, {**common_metadata, "reviews": reviews}, "Reviews")
     if fuzzables:
         export_metadata(blint_options.reports_dir, {**common_metadata, "fuzzables": fuzzables}, "Fuzzables")

--- a/blint/lib/analysis.py
+++ b/blint/lib/analysis.py
@@ -10,7 +10,6 @@ from itertools import islice
 from pathlib import Path
 
 import yaml
-from rich.progress import Progress
 from rich.terminal_theme import MONOKAI
 
 from blint.lib.binary import parse
@@ -315,18 +314,7 @@ def print_reviews_table(reviews, files):
     console.print(table)
 
 
-def json_serializer(obj):
-    """JSON serializer to help serialize problematic types such as bytes"""
-    if isinstance(obj, bytes):
-        try:
-            return obj.decode("utf-8")
-        except UnicodeDecodeError:
-            return ""
-
-    return obj
-
-
-def report(src_dir, reports_dir, findings, reviews, files, fuzzables):
+def report(blint_options, findings, reviews, fuzzables):
     """Generates a report based on the analysis results.
 
     Args:
@@ -338,354 +326,28 @@ def report(src_dir, reports_dir, findings, reviews, files, fuzzables):
         fuzzables: A list of fuzzable methods.
 
     """
+    if not findings and not reviews:
+        LOG.info(f":white_heavy_check_mark: No issues found in {blint_options.src_dir_image}!")
+        return
+    
+    if not os.path.exists(blint_options.reports_dir):
+        os.makedirs(blint_options.reports_dir)
     run_uuid = os.environ.get("SCAN_ID", str(uuid.uuid4()))
     common_metadata = {
         "scan_id": run_uuid,
         "created": f"{datetime.now():%Y-%m-%d %H:%M:%S%z}",
     }
     if findings:
-        print_findings_table(findings, files)
-        export_metadata(reports_dir, {**common_metadata, "findings": findings}, "findings")
+        print_findings_table(findings, blint_options.files)
+        export_metadata(blint_options.reports_dir, {**common_metadata, "findings": findings}, "Findings")
     if reviews:
-        print_reviews_table(reviews, files)
-        export_metadata(reports_dir, {**common_metadata, "reviews": reviews}, "reviews")
+        print_reviews_table(reviews, blint_options.files)
+        export_metadata(blint_options.reports_dir, {**common_metadata, "reviews": reviews}, "Reviews")
     if fuzzables:
-        export_metadata(reports_dir, {**common_metadata, "fuzzables": fuzzables}, "fuzzables")
+        export_metadata(blint_options.reports_dir, {**common_metadata, "fuzzables": fuzzables}, "Fuzzables")
     else:
         LOG.debug("No suggestion available for fuzzing")
-
-    if not findings and not reviews:
-        LOG.info(f":white_heavy_check_mark: No issues found in {src_dir}!")
     # Try console output as html
-    else:
-        html_file = Path(reports_dir) / "blint-output.html"
-        console.save_html(html_file, theme=MONOKAI)
-        LOG.info(f"HTML report written to {html_file}")
-
-
-class AnalysisRunner:
-    """Class to analyze binaries."""
-
-    def __init__(self):
-        self.findings = []
-        self.reviews = []
-        self.fuzzables = []
-        self.progress = Progress(
-            transient=True,
-            redirect_stderr=True,
-            redirect_stdout=True,
-            refresh_per_second=1,
-        )
-        self.task = None
-        self.reviewer = None
-
-    def start(self, files, reports_dir, no_reviews=False, suggest_fuzzables=True):
-        """Starts the analysis process for the given source files.
-
-        This function takes the command-line arguments and the reports
-        directory as input, and starts the analysis process. It iterates over
-        the source files, parses the metadata, checks the security properties,
-        performs symbol reviews, and suggests fuzzable targets if specified.
-
-        Args:
-            files (list): The list of source files to be analyzed.
-            reports_dir (str): The directory where the reports will be stored.
-            no_reviews (bool): Whether to perform reviews or not.
-            suggest_fuzzables (bool): Whether to suggest fuzzable targets or not.
-
-        Returns:
-            tuple: A tuple of the findings, reviews, files, and fuzzables.
-        """
-        with self.progress:
-            self.task = self.progress.add_task(
-                f"[green] BLinting {len(files)} binaries",
-                total=len(files),
-                start=True,
-            )
-            for f in files:
-                self._process_files(f, reports_dir, no_reviews, suggest_fuzzables)
-        return self.findings, self.reviews, self.fuzzables
-
-    def _process_files(self, f, reports_dir, no_reviews, suggest_fuzzables):
-        """Processes the given file and generates findings.
-
-        Args:
-            f (str): The file to be processed.
-            reports_dir (str): The directory where the reports will be stored.
-            no_reviews (bool): Whether to perform reviews or not.
-            suggest_fuzzables (bool): Whether to suggest fuzzable targets or not.
-
-        """
-        self.progress.update(self.task, description=f"Processing [bold]{f}[/bold]")
-        metadata = parse(f)
-        exe_name = metadata.get("name", "")
-        # Store raw metadata
-        export_metadata(reports_dir, metadata, f"{os.path.basename(exe_name)}-metadata")
-        self.progress.update(self.task, description=f"Checking [bold]{f}[/bold] against rules")
-        if finding := run_checks(f, metadata):
-            self.findings += finding
-        # Perform symbol reviews
-        if not no_reviews:
-            self.do_review(exe_name, f, metadata)
-        # Suggest fuzzable targets
-        if suggest_fuzzables and (fuzzdata := run_prefuzz(metadata)):
-            self.fuzzables.append(
-                {
-                    "filename": f,
-                    "exe_name": exe_name,
-                    "methods": fuzzdata,
-                }
-            )
-        self.progress.advance(self.task)
-
-    def do_review(self, exe_name, f, metadata):
-        """Performs a review of the given file."""
-        self.progress.update(self.task, description="Checking methods against review rules")
-        self.reviewer = ReviewRunner()
-        self.reviewer.run_review(metadata)
-        if self.reviewer.results:
-            review = self.reviewer.process_review(f, exe_name)
-            self.reviews += review
-
-
-class ReviewRunner:
-    """Class for running reviews."""
-
-    def __init__(self):
-        self.results = {}
-        self.review_methods_list = []
-        self.review_exe_list = []
-        self.review_symbols_list = []
-        self.review_imports_list = []
-        self.review_entries_list = []
-
-    def run_review(self, metadata):
-        """
-        Runs a review of the given file and metadata.
-
-        This function performs a review of the file and metadata based on the
-        available review methods for the executable type. It collects the
-        results from different review methods, including methods for functions,
-        symbols, imports, and dynamic entries.
-
-        Returns:
-            dict[str, list]: Review results where the keys are the review
-            method IDs and the values are lists of matching results.
-        """
-        if not review_methods_dict:
-            LOG.warning("No review methods loaded!")
-            return {}
-        if not metadata or not (exe_type := metadata.get("exe_type")):
-            return {}
-        self._gen_review_lists(exe_type)
-        # Check if reviews are available for this exe type
-        if (
-            self.review_methods_list
-            or self.review_exe_list
-            or self.review_symbols_list
-            or self.review_imports_list
-            or self.review_entries_list
-        ):
-            return self._review_lists(metadata)
-        return self._review_loader_symbols(metadata)
-
-    def _review_lists(self, metadata):
-        """
-        Reviews lists in the metadata and performs specific actions based on the
-        review type.
-
-        Args:
-            metadata (dict): The metadata to review.
-
-        Returns:
-            dict: The results of the review.
-        """
-        if self.review_methods_list or self.review_exe_list:
-            self._methods_or_exe(metadata)
-        if self.review_symbols_list or self.review_exe_list:
-            self._review_symbols_exe(metadata)
-        if self.review_imports_list:
-            self._review_imports(metadata)
-        if self.review_entries_list:
-            self._review_entries(metadata)
-        self._review_pii(metadata)
-        self._review_loader_symbols(metadata)
-        return self.results
-
-    def _review_imports(self, metadata):
-        """
-        Reviews imports in the metadata.
-
-        Args:
-            metadata (dict): The metadata to review.
-        """
-        imports_list = [f.get("name", "") for f in metadata.get("imports", [])]
-        LOG.debug(f"Reviewing {len(imports_list)} imports")
-        self.run_review_methods_symbols(self.review_imports_list, imports_list)
-
-    def _review_entries(self, metadata):
-        """
-        Reviews entries in the metadata and performs specific actions based on
-        the review type.
-
-        Args:
-            metadata (dict): The metadata to review.
-
-        Returns:
-            dict: The results of the review.
-        """
-        entries_list = [
-            f.get("name", "")
-            for f in metadata.get("dynamic_entries", [])
-            if f.get("tag") == "NEEDED"
-        ]
-        LOG.debug(f"Reviewing {len(entries_list)} dynamic entries")
-        self.run_review_methods_symbols(self.review_entries_list, entries_list)
-
-    def _review_pii(self, metadata):
-        """
-        Reviews pii symbols.
-
-        Args:
-            metadata (dict): The metadata to review.
-
-        Returns:
-            dict: The results of the review.
-        """
-        entries_list = [f.get("name", "") for f in metadata.get("pii_symbols", [])]
-        results = defaultdict(list)
-        for e in entries_list[0:EVIDENCE_LIMIT]:
-            results["PII_READ"].append({"pattern": e, "function": e})
-        self.results |= results
-
-    def _review_loader_symbols(self, metadata):
-        """
-        Reviews loader symbols.
-
-        Args:
-            metadata (dict): The metadata to review.
-
-        Returns:
-            dict: The results of the review.
-        """
-        entries_list = [f.get("name", "") for f in metadata.get("first_stage_symbols", [])]
-        results = defaultdict(list)
-        for e in entries_list[0:EVIDENCE_LIMIT]:
-            results["LOADER_SYMBOLS"].append({"pattern": e, "function": e})
-        self.results |= results
-
-    def _review_symbols_exe(self, metadata):
-        """
-        Reviews symbols in the metadata.
-
-        Args:
-            metadata (dict): The metadata to review.
-        """
-        symbols_list = [f.get("name", "") for f in metadata.get("dynamic_symbols", [])]
-        symbols_list += [f.get("name", "") for f in metadata.get("symtab_symbols", [])]
-        LOG.debug(f"Reviewing {len(symbols_list)} symbols")
-        if self.review_symbols_list:
-            self.run_review_methods_symbols(self.review_symbols_list, symbols_list)
-        if self.review_exe_list:
-            self.run_review_methods_symbols(self.review_exe_list, symbols_list)
-
-    def _methods_or_exe(self, metadata):
-        """
-        Reviews lists in the metadata and performs specific actions based on the
-        review type.
-
-        Args:
-            metadata (dict): The metadata to review.
-        """
-        functions_list = [
-            re.sub(r"[*&()]", "", f.get("name", "")) for f in metadata.get("functions", [])
-        ]
-        if metadata.get("magic", "").startswith("PE"):
-            functions_list += [f.get("name", "") for f in metadata.get("symtab_symbols", [])]
-        # If there are no function but static symbols use that instead
-        if not functions_list and metadata.get("symtab_symbols"):
-            functions_list = [f.get("name", "") for f in metadata.get("symtab_symbols", [])]
-        LOG.debug(f"Reviewing {len(functions_list)} functions")
-        if self.review_methods_list:
-            self.run_review_methods_symbols(self.review_methods_list, functions_list)
-        if self.review_exe_list:
-            self.run_review_methods_symbols(self.review_exe_list, functions_list)
-
-    def _gen_review_lists(self, exe_type):
-        """
-        Generates the review lists based on the given executable type.
-
-        This function takes the executable type as input and generates the
-        review lists for the corresponding type. It retrieves the review lists
-        from the review dictionaries based on the executable type.
-        """
-        self.review_methods_list = review_methods_dict.get(exe_type)
-        self.review_exe_list = review_exe_dict.get(exe_type)
-        self.review_symbols_list = review_symbols_dict.get(exe_type)
-        self.review_imports_list = review_imports_dict.get(exe_type)
-        self.review_entries_list = review_entries_dict.get(exe_type)
-
-    def process_review(self, f, exe_name):
-        """
-        Processes the review results for the given executable and review.
-
-        Returns:
-            list[dict]: The processed review result.
-        """
-        reviews = []
-        if not self.results:
-            return {}
-        for cid, evidence in self.results.items():
-            aresult = {
-                **review_rules_cache.get(cid),
-                "evidence": evidence,
-                "filename": f,
-                "exe_name": exe_name,
-            }
-            del aresult["patterns"]
-            reviews.append(aresult)
-        return reviews
-
-    def run_review_methods_symbols(self, review_list, functions_list):
-        """Runs a review of methods and symbols based on the provided lists.
-
-        This function takes a list of review methods and a list of functions and
-        performs a review to find matches between the patterns specified in the
-        review methods and the functions. It returns a dictionary of results
-        where the keys are the review method IDs and the values are lists of
-        matching results.
-
-        Args:
-            review_list (list[dict]): The review methods or symbols.
-            functions_list (list): A list of functions to be reviewed.
-
-        Returns:
-            dict[str, list]: Method/symbol IDs and their results.
-        """
-        results = defaultdict(list)
-        found_cid = defaultdict(int)
-        found_pattern = defaultdict(int)
-        found_function = {}
-        if not review_list:
-            return
-        for review_methods in review_list:
-            for cid, rule_obj in review_methods.items():
-                if found_cid[cid] > EVIDENCE_LIMIT:
-                    continue
-                patterns = rule_obj.get("patterns")
-                for apattern in patterns:
-                    if found_pattern[apattern] > EVIDENCE_LIMIT or found_cid[cid] > EVIDENCE_LIMIT:
-                        continue
-                    for afun in functions_list:
-                        if apattern.lower() in afun.lower() and not found_function.get(
-                            afun.lower()
-                        ):
-                            result = {
-                                "pattern": apattern,
-                                "function": afun,
-                            }
-                            results[cid].append(result)
-                            found_cid[cid] += 1
-                            found_pattern[apattern] += 1
-                            found_function[afun.lower()] = True
-        self.results |= results
+    html_file = Path(blint_options.reports_dir) / "blint-output.html"
+    console.save_html(html_file, theme=MONOKAI)
+    LOG.info(f"HTML report written to {html_file}")

--- a/blint/lib/analysis.py
+++ b/blint/lib/analysis.py
@@ -29,7 +29,12 @@ from blint.lib.checks import (
 )
 from blint.config import FIRST_STAGE_WORDS, PII_WORDS, get_int_from_env
 from blint.logger import LOG, console
-from blint.lib.utils import create_findings_table, is_fuzzable_name, print_findings_table
+from blint.lib.utils import (
+    create_findings_table,
+    is_fuzzable_name,
+    print_findings_table,
+    export_metadata
+)
 
 try:
     import importlib.resources  # pylint: disable=ungrouped-imports

--- a/blint/lib/analysis.py
+++ b/blint/lib/analysis.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from itertools import islice
 from pathlib import Path
 
-import orjson
 import yaml
 from rich.progress import Progress
 from rich.terminal_theme import MONOKAI
@@ -346,30 +345,12 @@ def report(src_dir, reports_dir, findings, reviews, files, fuzzables):
     }
     if findings:
         print_findings_table(findings, files)
-        findings_file = Path(reports_dir) / "findings.json"
-        LOG.info(f"Findings written to {findings_file}")
-        output = orjson.dumps(
-            {**common_metadata, "findings": findings}, default=json_serializer
-        ).decode("utf-8", "ignore")
-        with open(findings_file, mode="w", encoding="utf-8") as ffp:
-            ffp.write(output)
+        export_metadata(reports_dir, {**common_metadata, "findings": findings}, "findings")
     if reviews:
         print_reviews_table(reviews, files)
-        reviews_file = Path(reports_dir) / "reviews.json"
-        LOG.info(f"Review written to {reviews_file}")
-        output = orjson.dumps(
-            {**common_metadata, "reviews": reviews}, default=json_serializer
-        ).decode("utf-8", "ignore")
-        with open(reviews_file, mode="w", encoding="utf-8") as rfp:
-            rfp.write(output)
+        export_metadata(reports_dir, {**common_metadata, "reviews": reviews}, "reviews")
     if fuzzables:
-        fuzzables_file = Path(reports_dir) / "fuzzables.json"
-        LOG.info(f"Fuzzables data written to {fuzzables_file}")
-        output = orjson.dumps(
-            {**common_metadata, "fuzzables": fuzzables}, default=json_serializer
-        ).decode("utf-8", "ignore")
-        with open(fuzzables_file, mode="w", encoding="utf-8") as rfp:
-            rfp.write(output)
+        export_metadata(reports_dir, {**common_metadata, "fuzzables": fuzzables}, "fuzzables")
     else:
         LOG.debug("No suggestion available for fuzzing")
 
@@ -439,11 +420,7 @@ class AnalysisRunner:
         metadata = parse(f)
         exe_name = metadata.get("name", "")
         # Store raw metadata
-        metadata_file = Path(reports_dir) / f"{os.path.basename(exe_name)}" f"-metadata.json"
-        LOG.debug(f"Metadata written to {metadata_file}")
-        output = orjson.dumps(metadata, default=json_serializer).decode("utf-8", "ignore")
-        with open(metadata_file, mode="w", encoding="utf-8") as ffp:
-            ffp.write(output)
+        export_metadata(reports_dir, metadata, f"{os.path.basename(exe_name)}-metadata")
         self.progress.update(self.task, description=f"Checking [bold]{f}[/bold] against rules")
         if finding := run_checks(f, metadata):
             self.findings += finding

--- a/blint/lib/android.py
+++ b/blint/lib/android.py
@@ -5,6 +5,9 @@ import sys
 import tempfile
 
 from blint.lib.binary import parse, parse_dex
+from custom_json_diff.lib.utils import file_read
+
+from blint.binary import parse, parse_dex
 from blint.config import SYMBOL_DELIMITER
 from blint.cyclonedx.spec import (
     Component,
@@ -15,6 +18,7 @@ from blint.cyclonedx.spec import (
 )
 from blint.logger import LOG
 from blint.lib.utils import check_command, create_component_evidence, find_files, unzip_unsafe
+
 
 ANDROID_HOME = os.getenv("ANDROID_HOME")
 APKANALYZER_CMD = os.getenv("APKANALYZER_CMD")

--- a/blint/lib/android.py
+++ b/blint/lib/android.py
@@ -134,16 +134,15 @@ def collect_version_files_metadata(app_file, app_temp_dir):
         name = ""
         if "_" in file_name:
             group, name = parse_file_name(file_name, group)
-        with open(vf, encoding="utf-8") as fp:
-            version_data = fp.read().strip()
-            # Sometimes the version data could be dynamic. Eg:
-            #   task ':lifecycle:lifecycle-viewmodel:writeVersionFile' property 'version'"
-            # These can be treated as dynamic
-            if version_data and version_data.startswith("task"):
+        # Sometimes the version data could be dynamic. Eg:
+        #   task ':lifecycle:lifecycle-viewmodel:writeVersionFile' property 'version'"
+        # These can be treated as dynamic
+        if version_data := file_read(vf, False, log=LOG).strip():
+            if version_data.startswith("task"):
                 version_data = "dynamic"
-        if name and version_data:
-            component = create_version_component(app_file, group, name, rel_path, version_data)
-            file_components.append(component)
+            if name:
+                component = create_version_component(app_file, group, name, rel_path, version_data)
+                file_components.append(component)
     return file_components
 
 

--- a/blint/lib/android.py
+++ b/blint/lib/android.py
@@ -7,7 +7,7 @@ import tempfile
 from blint.lib.binary import parse, parse_dex
 from custom_json_diff.lib.utils import file_read
 
-from blint.binary import parse, parse_dex
+from blint.lib.binary import parse, parse_dex
 from blint.config import SYMBOL_DELIMITER
 from blint.cyclonedx.spec import (
     Component,

--- a/blint/lib/runners.py
+++ b/blint/lib/runners.py
@@ -61,7 +61,7 @@ class AnalysisRunner:
         self.task = None
         self.reviewer = None
 
-    def start(self, blint_options):
+    def start(self, blint_options, exe_files):
         """Starts the analysis process for the given source files.
 
         This function takes the command-line arguments and the reports
@@ -80,11 +80,11 @@ class AnalysisRunner:
         """
         with self.progress:
             self.task = self.progress.add_task(
-                f"[green] BLinting {len(blint_options.files)} binaries",
-                total=len(blint_options.files),
+                f"[green] BLinting {len(exe_files)} binaries",
+                total=len(exe_files),
                 start=True,
             )
-            for f in blint_options.files:
+            for f in exe_files:
                 self._process_files(f, blint_options)
         return self.findings, self.reviews, self.fuzzables
 

--- a/blint/lib/runners.py
+++ b/blint/lib/runners.py
@@ -1,0 +1,373 @@
+import logging
+import os
+import re
+import sys
+from collections import defaultdict
+
+from rich.progress import Progress
+from blint.analysis import (
+    EVIDENCE_LIMIT,
+    report,
+    review_entries_dict, review_exe_dict,
+    review_imports_dict, review_methods_dict,
+    review_rules_cache, review_symbols_dict, run_checks,
+    run_prefuzz
+)
+from blint.binary import parse
+from blint.logger import LOG
+from blint.sbom import generate
+from blint.utils import export_metadata, find_android_files, gen_file_list
+
+
+def run_sbom_mode(blint_options):
+    if blint_options.stdout_mode:
+        LOG.setLevel(logging.ERROR)
+    else:
+        if blint_options.sbom_output_dir and not os.path.exists(blint_options.sbom_output_dir):
+            os.makedirs(blint_options.sbom_output_dir)
+    exe_files = gen_file_list(blint_options.src_dir_image)
+    android_files = []
+    for src in blint_options.src_dir_image:
+        if files := find_android_files(src):
+            android_files += files
+    generate(blint_options, exe_files, android_files)
+
+
+def run_default_mode(blint_options):
+    exe_files = gen_file_list(blint_options.src_dir_image)
+    analyzer = AnalysisRunner()
+    findings, reviews, fuzzables = analyzer.start(blint_options, exe_files)
+    report(blint_options, exe_files, findings, reviews, fuzzables)
+    
+    if os.getenv("CI") and not blint_options.no_error:
+        for f in findings:
+            if f['severity'] == 'critical':
+                sys.exit(1)
+
+
+class AnalysisRunner:
+    """Class to analyze binaries."""
+
+    def __init__(self):
+        self.findings = []
+        self.reviews = []
+        self.fuzzables = []
+        self.progress = Progress(
+            transient=True,
+            redirect_stderr=True,
+            redirect_stdout=True,
+            refresh_per_second=1,
+        )
+        self.task = None
+        self.reviewer = None
+
+    def start(self, blint_options):
+        """Starts the analysis process for the given source files.
+
+        This function takes the command-line arguments and the reports
+        directory as input, and starts the analysis process. It iterates over
+        the source files, parses the metadata, checks the security properties,
+        performs symbol reviews, and suggests fuzzable targets if specified.
+
+        Args:
+            files (list): The list of source files to be analyzed.
+            reports_dir (str): The directory where the reports will be stored.
+            no_reviews (bool): Whether to perform reviews or not.
+            suggest_fuzzables (bool): Whether to suggest fuzzable targets or not.
+
+        Returns:
+            tuple: A tuple of the findings, reviews, files, and fuzzables.
+        """
+        with self.progress:
+            self.task = self.progress.add_task(
+                f"[green] BLinting {len(blint_options.files)} binaries",
+                total=len(blint_options.files),
+                start=True,
+            )
+            for f in blint_options.files:
+                self._process_files(f, blint_options)
+        return self.findings, self.reviews, self.fuzzables
+
+    def _process_files(self, f, blint_options):
+        """Processes the given file and generates findings.
+
+        Args:
+            f (str): The file to be processed.
+            reports_dir (str): The directory where the reports will be stored.
+            no_reviews (bool): Whether to perform reviews or not.
+            suggest_fuzzables (bool): Whether to suggest fuzzable targets or not.
+
+        """
+        self.progress.update(self.task, description=f"Processing [bold]{f}[/bold]")
+        metadata = parse(f)
+        exe_name = metadata.get("name", "")
+        # Store raw metadata
+        export_metadata(blint_options.reports_dir, metadata, f"{os.path.basename(exe_name)}-metadata")
+        self.progress.update(self.task, description=f"Checking [bold]{f}[/bold] against rules")
+        if finding := run_checks(f, metadata):
+            self.findings += finding
+        # Perform symbol reviews
+        if not blint_options.no_reviews:
+            self.do_review(exe_name, f, metadata)
+        # Suggest fuzzable targets
+        if blint_options.fuzzy and (fuzzdata := run_prefuzz(metadata)):
+            self.fuzzables.append(
+                {
+                    "filename": f,
+                    "exe_name": exe_name,
+                    "methods": fuzzdata,
+                }
+            )
+        self.progress.advance(self.task)
+
+    def do_review(self, exe_name, f, metadata):
+        """Performs a review of the given file."""
+        self.progress.update(self.task, description="Checking methods against review rules")
+        self.reviewer = ReviewRunner()
+        self.reviewer.run_review(metadata)
+        if self.reviewer.results:
+            review = self.reviewer.process_review(f, exe_name)
+            self.reviews += review
+
+
+class ReviewRunner:
+    """Class for running reviews."""
+
+    def __init__(self):
+        self.results = {}
+        self.review_methods_list = []
+        self.review_exe_list = []
+        self.review_symbols_list = []
+        self.review_imports_list = []
+        self.review_entries_list = []
+
+    def run_review(self, metadata):
+        """
+        Runs a review of the given file and metadata.
+
+        This function performs a review of the file and metadata based on the
+        available review methods for the executable type. It collects the
+        results from different review methods, including methods for functions,
+        symbols, imports, and dynamic entries.
+
+        Returns:
+            dict[str, list]: Review results where the keys are the review
+            method IDs and the values are lists of matching results.
+        """
+        if not review_methods_dict:
+            LOG.warning("No review methods loaded!")
+            return {}
+        if not metadata or not (exe_type := metadata.get("exe_type")):
+            return {}
+        self._gen_review_lists(exe_type)
+        # Check if reviews are available for this exe type
+        if (
+            self.review_methods_list
+            or self.review_exe_list
+            or self.review_symbols_list
+            or self.review_imports_list
+            or self.review_entries_list
+        ):
+            return self._review_lists(metadata)
+        return self._review_loader_symbols(metadata)
+
+    def _review_lists(self, metadata):
+        """
+        Reviews lists in the metadata and performs specific actions based on the
+        review type.
+
+        Args:
+            metadata (dict): The metadata to review.
+
+        Returns:
+            dict: The results of the review.
+        """
+        if self.review_methods_list or self.review_exe_list:
+            self._methods_or_exe(metadata)
+        if self.review_symbols_list or self.review_exe_list:
+            self._review_symbols_exe(metadata)
+        if self.review_imports_list:
+            self._review_imports(metadata)
+        if self.review_entries_list:
+            self._review_entries(metadata)
+        self._review_pii(metadata)
+        self._review_loader_symbols(metadata)
+        return self.results
+
+    def _review_imports(self, metadata):
+        """
+        Reviews imports in the metadata.
+
+        Args:
+            metadata (dict): The metadata to review.
+        """
+        imports_list = [f.get("name", "") for f in metadata.get("imports", [])]
+        LOG.debug(f"Reviewing {len(imports_list)} imports")
+        self.run_review_methods_symbols(self.review_imports_list, imports_list)
+
+    def _review_entries(self, metadata):
+        """
+        Reviews entries in the metadata and performs specific actions based on
+        the review type.
+
+        Args:
+            metadata (dict): The metadata to review.
+
+        Returns:
+            dict: The results of the review.
+        """
+        entries_list = [
+            f.get("name", "")
+            for f in metadata.get("dynamic_entries", [])
+            if f.get("tag") == "NEEDED"
+        ]
+        LOG.debug(f"Reviewing {len(entries_list)} dynamic entries")
+        self.run_review_methods_symbols(self.review_entries_list, entries_list)
+
+    def _review_pii(self, metadata):
+        """
+        Reviews pii symbols.
+
+        Args:
+            metadata (dict): The metadata to review.
+
+        Returns:
+            dict: The results of the review.
+        """
+        entries_list = [f.get("name", "") for f in metadata.get("pii_symbols", [])]
+        results = defaultdict(list)
+        for e in entries_list[0:EVIDENCE_LIMIT]:
+            results["PII_READ"].append({"pattern": e, "function": e})
+        self.results |= results
+
+    def _review_loader_symbols(self, metadata):
+        """
+        Reviews loader symbols.
+
+        Args:
+            metadata (dict): The metadata to review.
+
+        Returns:
+            dict: The results of the review.
+        """
+        entries_list = [f.get("name", "") for f in metadata.get("first_stage_symbols", [])]
+        results = defaultdict(list)
+        for e in entries_list[0:EVIDENCE_LIMIT]:
+            results["LOADER_SYMBOLS"].append({"pattern": e, "function": e})
+        self.results |= results
+
+    def _review_symbols_exe(self, metadata):
+        """
+        Reviews symbols in the metadata.
+
+        Args:
+            metadata (dict): The metadata to review.
+        """
+        symbols_list = [f.get("name", "") for f in metadata.get("dynamic_symbols", [])]
+        symbols_list += [f.get("name", "") for f in metadata.get("symtab_symbols", [])]
+        LOG.debug(f"Reviewing {len(symbols_list)} symbols")
+        if self.review_symbols_list:
+            self.run_review_methods_symbols(self.review_symbols_list, symbols_list)
+        if self.review_exe_list:
+            self.run_review_methods_symbols(self.review_exe_list, symbols_list)
+
+    def _methods_or_exe(self, metadata):
+        """
+        Reviews lists in the metadata and performs specific actions based on the
+        review type.
+
+        Args:
+            metadata (dict): The metadata to review.
+        """
+        functions_list = [
+            re.sub(r"[*&()]", "", f.get("name", "")) for f in metadata.get("functions", [])
+        ]
+        if metadata.get("magic", "").startswith("PE"):
+            functions_list += [f.get("name", "") for f in metadata.get("symtab_symbols", [])]
+        # If there are no function but static symbols use that instead
+        if not functions_list and metadata.get("symtab_symbols"):
+            functions_list = [f.get("name", "") for f in metadata.get("symtab_symbols", [])]
+        LOG.debug(f"Reviewing {len(functions_list)} functions")
+        if self.review_methods_list:
+            self.run_review_methods_symbols(self.review_methods_list, functions_list)
+        if self.review_exe_list:
+            self.run_review_methods_symbols(self.review_exe_list, functions_list)
+
+    def _gen_review_lists(self, exe_type):
+        """
+        Generates the review lists based on the given executable type.
+
+        This function takes the executable type as input and generates the
+        review lists for the corresponding type. It retrieves the review lists
+        from the review dictionaries based on the executable type.
+        """
+        self.review_methods_list = review_methods_dict.get(exe_type)
+        self.review_exe_list = review_exe_dict.get(exe_type)
+        self.review_symbols_list = review_symbols_dict.get(exe_type)
+        self.review_imports_list = review_imports_dict.get(exe_type)
+        self.review_entries_list = review_entries_dict.get(exe_type)
+
+    def process_review(self, f, exe_name):
+        """
+        Processes the review results for the given executable and review.
+
+        Returns:
+            list[dict]: The processed review result.
+        """
+        reviews = []
+        if not self.results:
+            return {}
+        for cid, evidence in self.results.items():
+            aresult = {
+                **review_rules_cache.get(cid),
+                "evidence": evidence,
+                "filename": f,
+                "exe_name": exe_name,
+            }
+            del aresult["patterns"]
+            reviews.append(aresult)
+        return reviews
+
+    def run_review_methods_symbols(self, review_list, functions_list):
+        """Runs a review of methods and symbols based on the provided lists.
+
+        This function takes a list of review methods and a list of functions and
+        performs a review to find matches between the patterns specified in the
+        review methods and the functions. It returns a dictionary of results
+        where the keys are the review method IDs and the values are lists of
+        matching results.
+
+        Args:
+            review_list (list[dict]): The review methods or symbols.
+            functions_list (list): A list of functions to be reviewed.
+
+        Returns:
+            dict[str, list]: Method/symbol IDs and their results.
+        """
+        results = defaultdict(list)
+        found_cid = defaultdict(int)
+        found_pattern = defaultdict(int)
+        found_function = {}
+        if not review_list:
+            return
+        for review_methods in review_list:
+            for cid, rule_obj in review_methods.items():
+                if found_cid[cid] > EVIDENCE_LIMIT:
+                    continue
+                patterns = rule_obj.get("patterns")
+                for apattern in patterns:
+                    if found_pattern[apattern] > EVIDENCE_LIMIT or found_cid[cid] > EVIDENCE_LIMIT:
+                        continue
+                    for afun in functions_list:
+                        if apattern.lower() in afun.lower() and not found_function.get(
+                            afun.lower()
+                        ):
+                            result = {
+                                "pattern": apattern,
+                                "function": afun,
+                            }
+                            results[cid].append(result)
+                            found_cid[cid] += 1
+                            found_pattern[apattern] += 1
+                            found_function[afun.lower()] = True
+        self.results |= results

--- a/blint/lib/runners.py
+++ b/blint/lib/runners.py
@@ -5,7 +5,7 @@ import sys
 from collections import defaultdict
 
 from rich.progress import Progress
-from blint.analysis import (
+from blint.lib.analysis import (
     EVIDENCE_LIMIT,
     report,
     review_entries_dict, review_exe_dict,
@@ -13,10 +13,10 @@ from blint.analysis import (
     review_rules_cache, review_symbols_dict, run_checks,
     run_prefuzz
 )
-from blint.binary import parse
+from blint.lib.binary import parse
 from blint.logger import LOG
-from blint.sbom import generate
-from blint.utils import export_metadata, find_android_files, gen_file_list
+from blint.lib.sbom import generate
+from blint.lib.utils import export_metadata, find_android_files, gen_file_list
 
 
 def run_sbom_mode(blint_options):

--- a/blint/lib/sbom.py
+++ b/blint/lib/sbom.py
@@ -130,22 +130,22 @@ def generate(blint_options, exe_files, android_files) -> bool:
         redirect_stdout=True,
         refresh_per_second=1,
     ) as progress:
-        if blint_options.exe_files:
+        if exe_files:
             task = progress.add_task(
-                f"[green] Parsing {len(blint_options.exe_files)} binaries",
-                total=len(blint_options.exe_files),
+                f"[green] Parsing {len(exe_files)} binaries",
+                total=len(exe_files),
                 start=True,
             )
-        for exe in blint_options.exe_files:
+        for exe in exe_files:
             progress.update(task, description=f"Processing [bold]{exe}[/bold]", advance=1)
-            components += process_exe_file(dependencies_dict, blint_options.deep_mode, exe, sbom, blint_options.export_prefixes, symbols_purl_map)
-        if blint_options.android_files:
+            components += process_exe_file(dependencies_dict, blint_options.deep_mode, exe, sbom, blint_options.exports_prefix, symbols_purl_map)
+        if android_files:
             task = progress.add_task(
                 f"[green] Parsing {len(android_files)} android apps",
                 total=len(android_files),
                 start=True,
             )
-        for f in blint_options.android_files:
+        for f in android_files:
             progress.update(task, description=f"Processing [bold]{f}[/bold]", advance=1)
             components += process_android_file(dependencies_dict, blint_options.deep_mode, f, sbom)
     if dependencies_dict:

--- a/blint/lib/sbom.py
+++ b/blint/lib/sbom.py
@@ -176,7 +176,6 @@ def create_sbom(
     Returns:
         bool: True if the SBOM generation is successful, False otherwise.
     """
-    # Populate the components
     output_dir = os.path.split(output_file)[0]
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)

--- a/blint/lib/utils.py
+++ b/blint/lib/utils.py
@@ -9,13 +9,17 @@ import tempfile
 import zipfile
 from importlib.metadata import distribution
 from pathlib import Path
+from typing import Dict
 
 import lief
 from ar import Archive
+from custom_json_diff.lib.utils import file_write
 from defusedxml.ElementTree import fromstring, ParseError
+from orjson import orjson
 from rich import box
 from rich.table import Table
 
+from blint.analysis import json_serializer
 from blint.config import (
     ignore_directories,
     ignore_files,
@@ -551,3 +555,12 @@ def extract_ar(ar_file: str, to_dir: str | None = None) -> list[str]:
                     output.write(archive.open(entry, 'rb').read())
                     files_list.append(afile)
     return files_list
+
+
+def export_metadata(directory: str, metadata: Dict, mtype: str):
+    """
+    Exports metadata to file.
+    """
+    outfile = str(Path(directory) / f"{mtype.lower()}.json")
+    output = orjson.dumps(metadata, default=json_serializer).decode("utf-8", "ignore")
+    file_write(outfile, output, success_msg=f"{mtype} written to {outfile}", log=LOG)

--- a/poetry.lock
+++ b/poetry.lock
@@ -279,6 +279,27 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "custom-json-diff"
+version = "2.1.4"
+description = "CycloneDx BOM and Oasis CSAF diffing and comparison tool."
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "custom_json_diff-2.1.4-py3-none-any.whl", hash = "sha256:befd8a876706ecc3e0906b8aa29c037fce4a75ab64700f1c9beab71f7b310670"},
+    {file = "custom_json_diff-2.1.4.tar.gz", hash = "sha256:8b8e4eb48088dadb6dd8a930feeb28f7b46aab91cec30f781a01da9f3ea2e737"},
+]
+
+[package.dependencies]
+jinja2 = ">=3.1.4"
+json-flatten = ">=0.3"
+packageurl-python = ">=0.15.6"
+semver = ">=3.0.0"
+toml = ">=0.10"
+
+[package.extras]
+dev = ["mypy", "pytest"]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
@@ -409,6 +430,37 @@ files = [
 colors = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "jinja2"
+version = "3.1.4"
+description = "A very fast and expressive template engine."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
+    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "json-flatten"
+version = "0.3.1"
+description = "Python functions for flattening a JSON object to a single dictionary of pairs, and unflattening that dictionary back to a JSON object"
+optional = false
+python-versions = "*"
+files = [
+    {file = "json_flatten-0.3.1-py3-none-any.whl", hash = "sha256:26470dbe9d6d7eb1b7f69c59ba2ade9d52608a76b8443e4654f3adb9c78c1c3e"},
+    {file = "json_flatten-0.3.1.tar.gz", hash = "sha256:70e813acf431b1ab7e9eb7b98f5733d307d6b9d27b553a344904b9c8eafdad3a"},
+]
+
+[package.extras]
+test = ["black", "cogapp", "pytest"]
+
+[[package]]
 name = "lief"
 version = "0.15.1"
 description = "Library to instrument executable formats"
@@ -502,6 +554,76 @@ plugins = ["mdit-py-plugins"]
 profiling = ["gprof2dot"]
 rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+description = "Safely add untrusted strings to HTML/XML markup."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50"},
+    {file = "MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d"},
+    {file = "MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30"},
+    {file = "MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6"},
+    {file = "MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f"},
+    {file = "MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a"},
+    {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
+]
 
 [[package]]
 name = "mccabe"
@@ -633,6 +755,23 @@ files = [
     {file = "orjson-3.10.12-cp39-none-win_amd64.whl", hash = "sha256:be604f60d45ace6b0b33dd990a66b4526f1a7a186ac411c942674625456ca548"},
     {file = "orjson-3.10.12.tar.gz", hash = "sha256:0a78bbda3aea0f9f079057ee1ee8a1ecf790d4f1af88dd67493c6b8ee52506ff"},
 ]
+
+[[package]]
+name = "packageurl-python"
+version = "0.16.0"
+description = "A purl aka. Package URL parser and builder"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "packageurl_python-0.16.0-py3-none-any.whl", hash = "sha256:5c3872638b177b0f1cf01c3673017b7b27ebee485693ae12a8bed70fa7fa7c35"},
+    {file = "packageurl_python-0.16.0.tar.gz", hash = "sha256:69e3bf8a3932fe9c2400f56aaeb9f86911ecee2f9398dbe1b58ec34340be365d"},
+]
+
+[package.extras]
+build = ["setuptools", "wheel"]
+lint = ["black", "isort", "mypy"]
+sqlalchemy = ["sqlalchemy (>=2.0.0)"]
+test = ["pytest"]
 
 [[package]]
 name = "packaging"
@@ -1089,6 +1228,17 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.1
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "semver"
+version = "3.0.2"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.2-py3-none-any.whl", hash = "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"},
+    {file = "semver-3.0.2.tar.gz", hash = "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"},
+]
+
+[[package]]
 name = "setuptools"
 version = "75.6.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1125,6 +1275,17 @@ files = [
 
 [package.dependencies]
 milksnake = ">=0.1.2"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
 
 [[package]]
 name = "tomli"
@@ -1192,4 +1353,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "c049dbc0124852c9bedcfb024228d8233228cbddf0b3f276cffa1f89e5ff0985"
+content-hash = "e3e251bd520096f82d15b926f8c09b6e3c2db883394cd73f3c5b9ef27f95853a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pydantic = {version = "^2.8.2", extras = ["email"]}
 orjson = "^3.10.6"
 symbolic = "10.2.1"
 ar = "^0.9.1"
-custom-json-diff = "~2.1.4"
+custom-json-diff = "~2.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pydantic = {version = "^2.8.2", extras = ["email"]}
 orjson = "^3.10.6"
 symbolic = "10.2.1"
 ar = "^0.9.1"
-custom-json-diff = "~2.2.0"
+custom-json-diff = "~2.1.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pydantic = {version = "^2.8.2", extras = ["email"]}
 orjson = "^3.10.6"
 symbolic = "10.2.1"
 ar = "^0.9.1"
+custom-json-diff = "~2.1.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,8 @@
 import orjson
 from pathlib import Path
 
-from blint.lib.analysis import ReviewRunner, run_checks
+from blint.lib.analysis import run_checks
+from blint.lib.runners import ReviewRunner
 
 
 def test_gobinary():


### PR DESCRIPTION
# Changes
- Extract logic previously stored in cli.py into lib functions in blint.lib.runners
- Introduce BlintOptions class to store the settings without depending on cli arguments
- Move appropriate modules to lib subpackage