### PR TITLE
update: fixed regex from detecting exe_type as gobinaries in elf bina…

### DIFF
--- a/blint/lib/binary.py
+++ b/blint/lib/binary.py
@@ -1295,7 +1295,7 @@ def add_rdata_symbols(metadata, rdata_section, text_section, sections):
     Returns:
         The updated metadata dictionary.
     """
-    file_extns_from_rdata = r".*\.(go|s|dll|exe|pdb)"
+    file_extns_from_rdata = r".*\.(go|s|dll|exe|pdb)(\s|$)"
     rdata_symbols = set()
     pii_symbols = []
     first_stage_symbols = []


### PR DESCRIPTION
Related to this issue: https://github.com/owasp-dep-scan/blint/issues/138 