### PR TITLE
Ci blint benchmark prototype workflow

### DIFF
--- a/.github/workflows/CI-BLINT-BENCH-80.yml
+++ b/.github/workflows/CI-BLINT-BENCH-80.yml
@@ -8,8 +8,13 @@ run-name: Prototype benchmarking tests ${{ github.ref_name }}
 # Required Secrets:
 # NONE
 #
-# WORK IN PROGRESS
-# search for "TODO" in file for more details on what is still un-implemented
+# Optional Workflow Variables:
+# - PYTHON_DEFAULT
+# - PYTHON_OLD_MIN
+# - PYTHON_EXPERIMENTAL
+
+# tip: use GitHub vars to override (e.g., zero code change to update)
+# hint: vars are either input via dispatch or set in repository settings
 
 on:  # yamllint disable-line rule:truthy
   push:
@@ -31,7 +36,7 @@ env:
   PYTHON_OLD_MIN: "${{ vars.PYTHON_OLD_MIN || '3.10' }}"  # For Oldest Python versions
   PYTHON_OLD_EXTRA: "${{ vars.PYTHON_OLD_EXTRA || '3.11' }}"  # For Older Python versions (Extra coverage)
   PYTHON_EXPERIMENTAL: "${{ vars.PYTHON_EXPERIMENTAL || '3.13' }}"  # For future Python versions
-  # define how mush time before assuming the test has hung in seconds (parsed by sleep)
+  # define how much time before assuming the test has hung in seconds (parsed by sleep)
   SUBSHELL_TIMEOUT: 3600
 
 jobs:
@@ -52,28 +57,28 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["${{ vars.PYTHON_OLD_MIN }}", "${{ vars.PYTHON_OLD_EXTRA }}", "${{ vars.PYTHON_DEFAULT }}", "${{ vars.PYTHON_EXPERIMENTAL }}"]
+        python-version: ["${{ vars.PYTHON_OLD_MIN || '3.10' }}", "${{ vars.PYTHON_OLD_EXTRA || '3.11' }}", "${{ vars.PYTHON_DEFAULT || '3.12' }}", "${{ vars.PYTHON_EXPERIMENTAL || '3.13' }}"]
         experimental: [true]
         target-path: ["/usr/bin", "/usr/lib", "/usr/sbin"]
         include:
           - os: ubuntu-latest
-            python-version: "${{ vars.PYTHON_DEFAULT }}"
+            python-version: "${{ vars.PYTHON_DEFAULT || '3.12' }}"
             experimental: false
             target-path: "/usr/bin"
           - os: macos-15
-            python-version: "${{ vars.PYTHON_EXPERIMENTAL }}"
+            python-version: "${{ vars.PYTHON_EXPERIMENTAL || '3.13' }}"
             experimental: true
             target-path: "/usr/libexec"
           - os: windows-latest
-            python-version: "${{ vars.PYTHON_DEFAULT }}"
+            python-version: "${{ vars.PYTHON_DEFAULT || '3.12' }}"
             experimental: true
             target-path: "$PATH"
           - os: macos-14
-            python-version: "${{ vars.PYTHON_DEFAULT }}"
+            python-version: "${{ vars.PYTHON_DEFAULT || '3.12' }}"
             experimental: true
             target-path: "/usr/lib"
           - os: windows-2025
-            python-version: "${{ vars.PYTHON_DEFAULT }}"
+            python-version: "${{ vars.PYTHON_DEFAULT || '3.12' }}"
             experimental: true
     outputs:
       bench_testing_status: ${{ steps.bench_testing.outcome }}


### PR DESCRIPTION
# Patch Notes

 * Contributes to GHI owasp-dep-scan/blint#80
   * Automates in CI-CD the task of setting up some bench-mark testing (starting with just `time`)
   * can be configured and extended to scan additional paths as needed (GHI #80 was vague)
 * **EDIT:** as of the latest commit (e.g., [c9eefd1](https://github.com/owasp-dep-scan/blint/pull/146/commits/c9eefd1112d4d1450658b590d20c4b34d2ac1a55) ) the workflow can be run with zero-configuration (will use fixed defaults for target python version)