### PR TITLE
Capture register interactions from instructions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -172,23 +172,15 @@ typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "attrs"
-version = "25.3.0"
+version = "25.4.0"
 description = "Classes Without Boilerplate"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
-    {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
+    {file = "attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373"},
+    {file = "attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11"},
 ]
-
-[package.extras]
-benchmark = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
-cov = ["cloudpickle ; platform_python_implementation == \"CPython\"", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
-dev = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pre-commit-uv", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
-docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier"]
-tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
-tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
 name = "black"
@@ -241,14 +233,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2025.8.3"
+version = "2025.10.5"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
-    {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
+    {file = "certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de"},
+    {file = "certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"},
 ]
 
 [[package]]
@@ -1348,14 +1340,14 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.9"
+version = "2.11.10"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2"},
-    {file = "pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2"},
+    {file = "pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a"},
+    {file = "pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423"},
 ]
 
 [package.dependencies]
@@ -1564,15 +1556,15 @@ setuptools = ">=42.0.0"
 
 [[package]]
 name = "pylint"
-version = "3.3.8"
+version = "3.3.9"
 description = "python code static checker"
 optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
 markers = "extra == \"dev\""
 files = [
-    {file = "pylint-3.3.8-py3-none-any.whl", hash = "sha256:7ef94aa692a600e82fabdd17102b73fc226758218c97473c7ad67bd4cb905d83"},
-    {file = "pylint-3.3.8.tar.gz", hash = "sha256:26698de19941363037e2937d3db9ed94fb3303fdadf7d98847875345a8bb6b05"},
+    {file = "pylint-3.3.9-py3-none-any.whl", hash = "sha256:01f9b0462c7730f94786c283f3e52a1fbdf0494bbe0971a78d7277ef46a751e7"},
+    {file = "pylint-3.3.9.tar.gz", hash = "sha256:d312737d7b25ccf6b01cc4ac629b5dcd14a0fcf3ec392735ac70f137a9d5f83a"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Inspired by this [comment](https://github.com/emproof-com/nyxstone/issues/34#issuecomment-2194469436).

```
"disassembled_functions": {
        "0xe28000::_init": {
            "name": "_init",
            "address": "0xe28000",
            "assembly": "endbr64\nsub rsp, 8\nmov rax, qword ptr [rip + 95911785]\ntest rax, rax\nje 2\ncall rax\ncall 19529301\nadd rsp, 8\nret",
            "assembly_hash": "8253433381195cf5506a62f1a2efdec55a16fcc64c5b0c12f9af745162a4badc",
            "instruction_hash": "927530f91dbf4d14c02f56b5adb89cb3e8bec5eaa13c0e59c9e4ccbb1c71c42c",
            "instruction_count": 9,
            "instruction_metrics": {
                "call_count": 2,
                "conditional_jump_count": 1,
                "xor_count": 0,
                "shift_count": 0,
                "arith_count": 2,
                "ret_count": 1,
                "jump_count": 0,
                "unique_regs_read_count": 12,
                "unique_regs_written_count": 12
            },
            "direct_calls": [],
            "has_indirect_call": false,
            "has_system_call": false,
            "has_security_feature": true,
            "has_crypto_call": false,
            "has_gpu_call": false,
            "has_loop": false,
            "regs_read": [
                "r8",
                "r9",
                "rax",
                "rcx",
                "r11",
                "r10",
                "rdi",
                "rsp",
                "rsi",
                "ax",
                "rdx",
                "sp"
            ],
            "regs_written": [
                "r8",
                "r9",
                "rax",
                "rcx",
                "r11",
                "r10",
                "rdi",
                "rsp",
                "rsi",
                "ax",
                "rdx",
                "sp"
            ],
            "instructions_with_registers": [
                {
                    "regs_read": [],
                    "regs_written": []
                },
                {
                    "regs_read": [
                        "rsp",
                        "sp"
                    ],
                    "regs_written": [
                        "rsp",
                        "sp"
                    ]
                },
                {
                    "regs_read": [],
                    "regs_written": [
                        "ax",
                        "rax"
                    ]
                },
                {
                    "regs_read": [
                        "ax",
                        "rax"
                    ],
                    "regs_written": []
                },
                {
                    "regs_read": [],
                    "regs_written": []
                },
                {
                    "regs_read": [
                        "ax",
                        "rax"
                    ],
                    "regs_written": [
                        "r8",
                        "r9",
                        "rax",
                        "rcx",
                        "r11",
                        "r10",
                        "rdi",
                        "rsi",
                        "rdx"
                    ]
                },
                {
                    "regs_read": [],
                    "regs_written": [
                        "r8",
                        "r9",
                        "rax",
                        "rcx",
                        "r11",
                        "r10",
                        "rdi",
                        "rsi",
                        "rdx"
                    ]
                },                
```
