### PR TITLE
Improved version detection

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,6 +9,6 @@
     <key>CFBundleName</key>
     <string>blint</string>
     <key>CFBundleVersion</key>
-    <string>3.0.2</string>
+    <string>3.0.3</string>
 </dict>
 </plist>

--- a/blint/lib/binary.py
+++ b/blint/lib/binary.py
@@ -394,6 +394,11 @@ def process_pe_resources(parsed_obj):
                 for e in lc_item.entries:
                     version_metadata[e.key] = e.value
     try:
+        version_info_dict = {}
+        if version_info:
+            for k in ("file_info", "key", "type"):
+                if hasattr(version_info, k):
+                    version_info_dict[k] = re.sub('\s+', ' ', str(getattr(version_info, k)))
         resources = {
             "has_accelerator": rm.has_accelerator,
             "has_dialogs": rm.has_dialogs,
@@ -407,7 +412,7 @@ def process_pe_resources(parsed_obj):
                 if rm.has_manifest
                 else None
             ),
-            "version_info": str(rm.version) if rm.has_version else None,
+            "version_info": version_info_dict,
             "html": rm.html if rm.has_html else None,
         }
         if version_metadata:

--- a/blint/lib/runners.py
+++ b/blint/lib/runners.py
@@ -101,7 +101,7 @@ class AnalysisRunner:
         """
         self.progress.update(self.task, description=f"Processing [bold]{f}[/bold]")
         metadata = parse(f, blint_options.disassemble)
-        exe_name = metadata.get("name", "")
+        exe_name = metadata.get("name", f)
         # Store raw metadata
         export_metadata(blint_options.reports_dir, metadata, f"{os.path.basename(exe_name)}-metadata")
         self.progress.update(self.task, description=f"Checking [bold]{f}[/bold] against rules")

--- a/file_version_info.txt
+++ b/file_version_info.txt
@@ -32,12 +32,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'OWASP Foundation'),
         StringStruct(u'FileDescription', u'blint - The Binary Linter'),
-        StringStruct(u'FileVersion', u'3.0.2.0'),
+        StringStruct(u'FileVersion', u'3.0.3.0'),
         StringStruct(u'InternalName', u'blint'),
         StringStruct(u'LegalCopyright', u'© OWASP Foundation. All rights reserved.'),
         StringStruct(u'OriginalFilename', u'blint.exe'),
         StringStruct(u'ProductName', u'blint'),
-        StringStruct(u'ProductVersion', u'3.0.2.0')])
+        StringStruct(u'ProductVersion', u'3.0.3.0')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blint"
-version = "3.0.2"
+version = "3.0.3"
 description = "Linter and SBOM generator for binary files."
 authors = [
     {name= "Team AppThreat", email = "cloud@appthreat.com"},


### PR DESCRIPTION
For libssl-3.dll, we get a `version_info` and a nice `ProductVersion`.

```
"resources": {
        "has_accelerator": false,
        "has_dialogs": false,
        "has_html": false,
        "has_icons": false,
        "has_manifest": false,
        "has_string_table": false,
        "has_version": true,
        "manifest": null,
        "version_info": {
            "file_info": "Struct Version : 0x010000 File version : 3-0-18-0 Product version : 3-0-18-0 File OS : WINDOWS32 (0x00000004) File Type : DLL (0x00000002) ",
            "key": "VS_VERSION_INFO",
            "type": "0"
        },
        "html": null,
        "version_metadata": {
            "CompanyName": "The OpenSSL Project, https://www.openssl.org/",
            "FileDescription": "OpenSSL library",
            "FileVersion": "3.0.18",
            "InternalName": "libssl",
            "OriginalFilename": "libssl",
            "ProductName": "The OpenSSL Toolkit",
            "ProductVersion": "3.0.18",
            "LegalCopyright": "Copyright 1998-2025 The OpenSSL Authors. All rights reserved."
        }
    },
```
[libssl-3.dll-metadata.json.zip](https://github.com/user-attachments/files/23095607/libssl-3.dll-metadata.json.zip)

