### PR TITLE
Added a check to the process_pe_resources function

### DIFF
--- a/blint/lib/binary.py
+++ b/blint/lib/binary.py
@@ -396,7 +396,8 @@ def process_pe_resources(parsed_obj):
     version_metadata = {}
     version_info = rm.version if rm.has_version else None
     if isinstance(version_info, list) and len(version_info):
-        version_info = version_info[0]
+        if not isinstance(version_info[0], lief.lief_errors):
+            version_info = version_info[0]
     if version_info and hasattr(version_info, "string_file_info"):
         string_file_info: lief.PE.ResourceStringFileInfo = version_info.string_file_info
         for lc_item in string_file_info.children:


### PR DESCRIPTION
Issue existed with how the process_pe_resources function handles lief.lief_errors when processing version information, which could lead to an AttributeErrors. Fixed it by adding a check to ensure version_info is not a lief.lief_errors object before trying to access its attributes.