### PR TITLE
Rust dependencies from panic messages

### DIFF
--- a/blint/lib/binary.py
+++ b/blint/lib/binary.py
@@ -1392,7 +1392,12 @@ def recover_rust_deps_from_panic(parsed_obj: lief.Binary) -> list:
             except (UnicodeDecodeError, AttributeError):
                 continue
     return [
-        {"name": name, "version": version} for name, version in detected_deps.keys()
+        {
+            "name": name,
+            "version": version,
+            "purl": f"pkg:cargo/{name}@{version}" if version else f"pkg:cargo/{name}",
+        }
+        for name, version in detected_deps.keys()
     ]
 
 

--- a/blint/lib/sbom.py
+++ b/blint/lib/sbom.py
@@ -835,11 +835,13 @@ def process_rust_dependencies(
         idx_to_purl[idx] = f"""pkg:cargo/{dep["name"]}@{dep["version"]}"""
     for dependency in rust_deps:
         purl = f"""pkg:cargo/{dependency["name"]}@{dependency["version"]}"""
-        purl_qualifer = (
-            f"""?repository={dependency.get("source")}"""
-            if dependency.get("source", "") != "crates.io"
-            else ""
-        )
+        purl_qualifer = ""
+        if dependency.get("source"):
+            purl_qualifer = (
+                f"""?repository={dependency.get("source")}"""
+                if dependency.get("source", "") != "crates.io"
+                else ""
+            )
         comp = Component(
             type=Type.library,
             name=dependency["name"],


### PR DESCRIPTION
Fixes #130 

Tested with the binaries from [here](https://github.com/rustsec/rustsec/releases/tag/cargo-audit%2Fv0.21.2) in normal as well as disassemble mode.

[reports.zip](https://github.com/user-attachments/files/23675428/reports.zip)
[reports.zip](https://github.com/user-attachments/files/23675444/reports.zip)

```
"rust_dependencies": [
        {
            "name": "toml_edit",
            "version": "0.22.22"
        },
        {
            "name": "arc-swap",
            "version": "1.7.1"
        },
        {
            "name": "serde",
            "version": "1.0.213"
        },
        {
            "name": "abscissa_core",
            "version": "0.8.2"
        },
        {
            "name": "winnow",
            "version": "0.6.20"
        },
        {
            "name": "clap_builder",
            "version": "4.5.20"
        },
        {
            "name": "termcolor",
            "version": "1.4.1"
        },
        {
            "name": "gix-pack",
            "version": "0.57.0"
        },
        {
            "name": "gix-features",
            "version": "0.40.0"
        },
        {
            "name": "gix-protocol",
            "version": "0.48.0"
        },
```