### PR TITLE
ELF dlopen support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             binary_name: blint-linux-amd64
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             binary_name: blint-linux-arm64
     permissions:
       contents: write

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
+      - release/*
+    tags:
+      - 'v*'
   pull_request:
-  tags:
-    - 'v*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,11 +5,21 @@ on:
     branches:
       - main
   pull_request:
+  tags:
+    - 'v*'
   workflow_dispatch:
 
 jobs:
   Blint-GNU-Build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            binary_name: blint-linux-amd64
+          - os: ubuntu-22.04-arm
+            binary_name: blint-linux-arm64
     permissions:
       contents: write
       packages: write
@@ -41,26 +51,26 @@ jobs:
         pyinstaller blint/cli.py --noconfirm --log-level=WARN \
           --nowindow \
           --onefile \
-          --name blint \
+          --name ${{ matrix.binary_name }} \
           --add-data="blint/data:blint/data" \
           --add-data="blint/data/annotations:blint/data/annotations" \
           --collect-submodules blint \
-          --collect-submodules symbolic \
+          --collect-submodules multi-demangle \
           --collect-submodules oras \
           --noupx
-        ./dist/blint -i dist/blint -o /tmp/reports
-        sha256sum ./dist/blint > ./dist/blint.sha256
+        ./dist/${{ matrix.binary_name }} -i dist/${{ matrix.binary_name }} -o /tmp/reports
+        sha256sum ./dist/${{ matrix.binary_name }} > ./dist/${{ matrix.binary_name }}.sha256
       env:
         PYTHONIOENCODING: utf-8
         LANG: en_US.utf-8
     - uses: actions/upload-artifact@v4
       with:
         path: ./blint/dist
-        name: blint-linux-gnu
+        name: ${{ matrix.binary_name }}
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          blint/dist/blint
-          blint/dist/blint.sha256
+          blint/dist/${{ matrix.binary_name }}
+          blint/dist/${{ matrix.binary_name }}.sha256    

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  tags:
+    - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -35,7 +37,7 @@ jobs:
     - name: Binary windows build
       run: |
         cd blint
-        pyinstaller blint/cli.py --noconfirm --log-level=WARN --nowindow --onefile --name blint --add-data="blint/data;blint/data" --add-data="blint/data/annotations;blint/data/annotations" --collect-submodules blint --collect-submodules oras --disable-windowed-traceback -i blint.ico --version-file=file_version_info.txt --noupx
+        pyinstaller blint/cli.py --noconfirm --log-level=WARN --nowindow --onefile --name blint --add-data="blint/data;blint/data" --add-data="blint/data/annotations;blint/data/annotations" --collect-submodules blint --collect-submodules multi-demangle --collect-submodules oras --disable-windowed-traceback -i blint.ico --version-file=file_version_info.txt --noupx
         (Get-FileHash .\dist\blint.exe).hash | Out-File -FilePath .\dist\blint.exe.sha256
         set PYTHONIOENCODING=UTF-8
         .\dist\blint.exe -i .\dist\blint.exe -o reports --no-banner

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
+      - release/*
+    tags:
+      - 'v*'
   pull_request:
-  tags:
-    - 'v*'
   workflow_dispatch:
 
 jobs:

--- a/Info.plist
+++ b/Info.plist
@@ -9,6 +9,6 @@
     <key>CFBundleName</key>
     <string>blint</string>
     <key>CFBundleVersion</key>
-    <string>3.0.7</string>
+    <string>3.1.0</string>
 </dict>
 </plist>

--- a/file_version_info.txt
+++ b/file_version_info.txt
@@ -32,12 +32,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'OWASP Foundation'),
         StringStruct(u'FileDescription', u'blint - The Binary Linter'),
-        StringStruct(u'FileVersion', u'3.0.7.0'),
+        StringStruct(u'FileVersion', u'3.1.0.0'),
         StringStruct(u'InternalName', u'blint'),
         StringStruct(u'LegalCopyright', u'© OWASP Foundation. All rights reserved.'),
         StringStruct(u'OriginalFilename', u'blint.exe'),
         StringStruct(u'ProductName', u'blint'),
-        StringStruct(u'ProductVersion', u'3.0.7.0')])
+        StringStruct(u'ProductVersion', u'3.1.0.0')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blint"
-version = "3.0.7"
+version = "3.1.0"
 description = "Linter and SBOM generator for binary files."
 authors = [
     {name= "Team AppThreat", email = "cloud@appthreat.com"},


### PR DESCRIPTION
Fixes #106 

Tested with libsystemd.so.0.41.0 from fedora rawhide.

https://uapi-group.org/specifications/specs/elf_dlopen_metadata/

[libsystemd.so.0.41.0-metadata.json](https://github.com/user-attachments/files/23677834/libsystemd.so.0.41.0-metadata.json)

```
"dlopen_dependencies": [
        {
            "name": "liblz4.so.1",
            "priority": "suggested",
            "features": [
                "lz4"
            ],
            "description": "Support lz4 compression in journal and coredump files"
        },
        {
            "name": "liblzma.so.5",
            "priority": "suggested",
            "features": [
                "lzma"
            ],
            "description": "Support lzma compression in journal and coredump files"
        },
        {
            "name": "libzstd.so.1",
            "priority": "recommended",
            "features": [
                "zstd"
            ],
            "description": "Support zstd compression in journal and coredump files"
        }
    ]
```

Reviewed with Gemini 3 pro.