### PR TITLE
fix: improve review rule pattern handling and clarify min_patterns doc

### DIFF
--- a/blint/data/annotations/review_rpc_win.yml
+++ b/blint/data/annotations/review_rpc_win.yml
@@ -55,7 +55,6 @@ rules:
       - DhcpClient
       - dhcpcsvc
       - DhcpSvc
-      - Dhcp
       - dhcpcore.dll
       - dhcpcore6.dll
       - 3c4728c5-f0ab-448b-bda1-6ce01eb0a6d5
@@ -63,6 +62,7 @@ rules:
       - RpcSrvEnableDhcp
       - RpcSrvRenewLease
       - RpcSrvRequestPrefixEx
+      - Dhcp
   - id: RPC_GPSVC_ARTIFACTS
     title: Contains Group Policy service RPC artifacts
     summary: Contains multiple gpsvc interface identifiers associated with the published PhantomRPC coercion path.
@@ -70,8 +70,8 @@ rules:
       This binary contains multiple identifiers associated with the Group Policy Client service RPC interface inventory used in PhantomRPC-style research, such as the gpsvc interface UUID, module name, or representative server procedure names. This is an artifact review only and does not prove exploitation.
     min_patterns: 2
     patterns:
-      - gpsvc
       - gpsvc.dll
+      - gpsvc
       - 2eb08e3e-639f-4fba-97b1-14f878961076
       - Server_ProcessRefresh
       - Server_RegisterForNotification

--- a/blint/lib/runners.py
+++ b/blint/lib/runners.py
@@ -44,6 +44,11 @@ def _coerce_rule_bool(value) -> bool:
             return True
         if normalized in ("false", "no", "0", "off", ""):
             return False
+        LOG.debug(
+            "Unrecognized boolean string value %r in review rule; defaulting to False",
+            value,
+        )
+        return False
     return bool(value)
 
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -27,7 +27,7 @@ Each rule within the `rules` list is a dictionary containing the following keys:
 - `summary` (Required): A brief summary of what the rule detects.
 - `description` (Required): A detailed description of the rule, explaining its purpose and the logic behind it.
 - `patterns` (Required for `METHOD_REVIEWS`, `SYMBOL_REVIEWS`, `IMPORT_REVIEWS`, `ENTRIES_REVIEWS`): A list of strings (case-insensitive) to search for within the target symbol/function/entry names. By default, one matching pattern is enough to trigger the rule; use `min_patterns` to require more than one distinct pattern match.
-- `min_patterns` (Optional for pattern-based review groups): Minimum number of distinct patterns from `patterns` that must match before the rule triggers. Defaults to `1`.
+- `min_patterns` (Optional for pattern-based review groups): Minimum number of distinct patterns from `patterns` that must match before the rule triggers. Each matched pattern must map to a distinct symbol/function/import name (a single name is consumed once per rule). Defaults to `1`.
 - `allow_shared_matches` (Optional for pattern-based review groups): If `true`, matched symbol/function/import names used by this rule are not consumed globally and may also satisfy other rules in the same review pass. Defaults to `false`.
 - `check_type` (Required for `FUNCTION_REVIEWS`): Specifies how the rule evaluates the `disassembled_functions` data. Valid types are:
   - `function_flag`: Checks if a specific boolean field within the function's metadata is `true`.

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -235,6 +235,27 @@ def test_run_review_methods_symbols_parses_rule_options_defensively():
     assert "RULE_TRUE_STRING" in reviewer.results
     assert "RULE_SHARED_SECOND" in reviewer.results
 
+    reviewer = ReviewRunner()
+    reviewer.run_review_methods_symbols(
+        [
+            {
+                "RULE_TYPO_STRING": {
+                    "patterns": ["RpcServerListen"],
+                    "allow_shared_matches": "flase",
+                }
+            },
+            {
+                "RULE_TYPO_SECOND": {
+                    "patterns": ["RpcServerListen"],
+                }
+            },
+        ],
+        functions_list,
+    )
+
+    assert "RULE_TYPO_STRING" in reviewer.results
+    assert "RULE_TYPO_SECOND" not in reviewer.results
+
 
 def test_safe_mermaid_label_sanitizes_parser_unsafe_chars():
     raw_label = ' unsafe extern "C" fn(*mut u8)\n\t\\windows\\path|core::fmt `tick` '


### PR DESCRIPTION
- Fix pattern consumption logic for review rules with allow_shared_matches typo handling
- Add test for typo in allow_shared_matches string value
- Clarify RULES.md documentation for min_patterns behavior
- Adjust DHCP and gpsvc patterns in review_rpc_win.yml for consistency
- Add debug log for unrecognized boolean string values in review rules