### PR TITLE
feat(checks): flag writable+executable segments (W^X violations)

### DIFF
--- a/blint/data/rules.yml
+++ b/blint/data/rules.yml
@@ -20,6 +20,24 @@
     - dotnetbinary
     - MachO
     - mips-executable
+- id: CHECK_WX_SEGMENTS
+  title: Writable and Executable Memory Segment
+  description: |
+    A loadable segment or section is mapped so that the same pages can be both written and executed. This breaks the Write XOR Execute (W^X) invariant: any memory-write primitive — a buffer overflow, a use-after-free, an unsafe deserialization routine — becomes direct code execution, because the pages the processor runs are the pages an attacker can modify.
+    Such mappings usually come from the link or pack step rather than the source: a single RWX `PT_LOAD` in firmware and binaries processed by older packer releases, a linker script or `-z execstack` build marking every loadable segment read-write-execute, or PE sections carrying `MEM_WRITE` together with `MEM_EXECUTE` after processing by some packers and legacy linkers.
+    Keep code segments read-only and executable (`R+X`) and data segments writable and non-executable (`R+W`). Runtime code generation and self-modifying code should write through a private writable mapping and only flip the executable view readable-executable for the duration of the update (`mprotect`/`VirtualProtect`), or use the JIT write-protection support provided by the runtime. `readelf -l` shows the offending segment as `LOAD ... RWE`; `objdump -h` and `dumpbin /headers` show the offending PE sections.
+    Beyond exploit mitigation, keeping data non-executable matters for correctness on ARM: non-executable permission is the only mechanism that prevents speculative instruction fetches to a region, so executable data or MMIO mappings can be speculatively fetched by mispredicted indirect branches with unpredictable results on some SoCs.
+  severity: critical
+  exe_types:
+    - genericbinary
+    - x86_64-executable
+    - x86_64-exec
+    - gobinary
+    - PE32
+    - PE64
+    - dotnetbinary
+    - MachO
+    - mips-executable
 - id: CHECK_PIE
   title: Missing Position-Independent Executable (PIE) Protection
   description: |

--- a/blint/lib/analysis.py
+++ b/blint/lib/analysis.py
@@ -37,6 +37,7 @@ from blint.lib.checks import (
     check_undeclared_dependencies,
     check_unused_dependencies,
     check_virtual_size,
+    check_wx_segments,
 )
 from blint.lib.utils import (
     create_findings_table,

--- a/blint/lib/binary.py
+++ b/blint/lib/binary.py
@@ -337,6 +337,118 @@ def parse_relro(parsed_obj: lief.ELF.Binary) -> str:
     return "full" if bind_now or now else "partial"
 
 
+def _rwx_permissions_str(readable: bool, writable: bool, executable: bool) -> str:
+    """Renders segment permissions in the customary ``rwx`` notation."""
+    return f"{'r' if readable else ''}{'w' if writable else ''}{'x' if executable else ''}"
+
+
+def parse_elf_wx_segments(parsed_obj: lief.ELF.Binary) -> list[dict]:
+    """Collects the loadable ELF segments mapped both writable and executable.
+
+    The GNU stack is deliberately excluded: an executable ``PT_GNU_STACK`` is
+    already reported as a missing-NX finding, so covering it here would report
+    the same defect twice.
+
+    Args:
+        parsed_obj: The parsed ELF binary.
+
+    Returns:
+        A list of segment descriptors with a name, normalized permissions and
+        the load address, usable as evidence for the W^X check.
+    """
+    wx_segments: list[dict] = []
+    segments = getattr(parsed_obj, "segments", None)
+    if not segments or isinstance(segments, lief.lief_errors):
+        return wx_segments
+    with contextlib.suppress(AttributeError, TypeError):
+        for index, segment in enumerate(segments):
+            if segment.type != lief.ELF.Segment.TYPE.LOAD:
+                continue
+            writable = segment.has(lief.ELF.Segment.FLAGS.W)
+            executable = segment.has(lief.ELF.Segment.FLAGS.X)
+            if writable and executable:
+                wx_segments.append(
+                    {
+                        "name": f"PT_LOAD[{index}]",
+                        "permissions": _rwx_permissions_str(
+                            segment.has(lief.ELF.Segment.FLAGS.R), writable, executable
+                        ),
+                        "virtual_address": ADDRESS_FMT.format(segment.virtual_address).strip(),
+                    }
+                )
+    return wx_segments
+
+
+def parse_pe_wx_sections(parsed_obj: lief.PE.Binary) -> list[dict]:
+    """Collects the PE sections the loader maps both writable and executable.
+
+    Args:
+        parsed_obj: The parsed PE binary.
+
+    Returns:
+        A list of section descriptors with a name, normalized permissions and
+        the relative virtual address, usable as evidence for the W^X check.
+    """
+    wx_sections: list[dict] = []
+    with contextlib.suppress(AttributeError, TypeError):
+        for section in parsed_obj.sections:
+            characteristics = section.characteristics_lists
+            writable = lief.PE.Section.CHARACTERISTICS.MEM_WRITE in characteristics
+            executable = lief.PE.Section.CHARACTERISTICS.MEM_EXECUTE in characteristics
+            if writable and executable:
+                wx_sections.append(
+                    {
+                        "name": section.name,
+                        "permissions": _rwx_permissions_str(
+                            lief.PE.Section.CHARACTERISTICS.MEM_READ in characteristics,
+                            writable,
+                            executable,
+                        ),
+                        "virtual_address": ADDRESS_FMT.format(section.virtual_address).strip(),
+                    }
+                )
+    return wx_sections
+
+
+# Segment protections carried by mach-o load commands (mach/vm_protect.h).
+VM_PROT_READ = 0x1
+VM_PROT_WRITE = 0x2
+VM_PROT_EXECUTE = 0x4
+
+
+def parse_mach0_wx_segments(parsed_obj: lief.MachO.Binary) -> list[dict]:
+    """Collects the Mach-O segments initially mapped both writable and executable.
+
+    Only ``init_protection`` counts as evidence: ``max_protection`` describes
+    what a segment may later be remapped to, not what it is mapped with, so a
+    permissive maximum alone does not mean writable code ever existed.
+
+    Args:
+        parsed_obj: The parsed MachO binary.
+
+    Returns:
+        A list of segment descriptors with a name, normalized permissions and
+        the virtual address, usable as evidence for the W^X check.
+    """
+    wx_segments: list[dict] = []
+    with contextlib.suppress(AttributeError, TypeError):
+        for segment in parsed_obj.segments:
+            protection = int(segment.init_protection)
+            writable = bool(protection & VM_PROT_WRITE)
+            executable = bool(protection & VM_PROT_EXECUTE)
+            if writable and executable:
+                wx_segments.append(
+                    {
+                        "name": segment.name,
+                        "permissions": _rwx_permissions_str(
+                            bool(protection & VM_PROT_READ), writable, executable
+                        ),
+                        "virtual_address": ADDRESS_FMT.format(segment.virtual_address).strip(),
+                    }
+                )
+    return wx_segments
+
+
 def parse_functions(functions) -> list[dict]:
     """
     Parses a list of functions and returns a list of dictionaries.
@@ -1774,6 +1886,9 @@ def construct_security_properties(metadata: dict, parsed_obj: lief.Binary) -> di
     has_symtab = metadata.get("static", False)
     properties = {
         "nx": metadata.get("has_nx", False),
+        # True when no loadable segment maps the same pages writable and
+        # executable, which trivially holds for formats without segments.
+        "w_xor_x": not metadata.get("wx_segments"),
         "pie": metadata.get("is_pie", False),
         "relro": metadata.get("relro", "no"),
         "canary": metadata.get("has_canary", False),
@@ -2561,6 +2676,7 @@ def add_elf_metadata(exe_file: str, metadata: dict, parsed_obj: lief.ELF.Binary)
     metadata["is_targeting_android"] = parsed_obj.is_targeting_android
     metadata["virtual_size"] = parsed_obj.virtual_size
     metadata["has_nx"] = parsed_obj.has_nx
+    metadata["wx_segments"] = parse_elf_wx_segments(parsed_obj)
     metadata["has_interpreter"] = parsed_obj.has_interpreter
     metadata["has_notes"] = parsed_obj.has_notes
     metadata["has_overlay"] = parsed_obj.has_overlay
@@ -3250,6 +3366,7 @@ def add_pe_metadata(exe_file: str, metadata: dict, parsed_obj: lief.PE.Binary) -
         metadata["is_reproducible_build"] = parsed_obj.is_reproducible_build
         metadata["virtual_size"] = parsed_obj.virtual_size
         metadata["has_nx"] = parsed_obj.has_nx
+        metadata["wx_segments"] = parse_pe_wx_sections(parsed_obj)
         metadata["imphash_pefile"] = lief.PE.get_imphash(parsed_obj, lief.PE.IMPHASH_MODE.PEFILE)
         metadata["imphash_lief"] = lief.PE.get_imphash(parsed_obj, lief.PE.IMPHASH_MODE.LIEF)
         metadata = add_pe_header_data(metadata, parsed_obj)
@@ -3576,6 +3693,7 @@ def add_mach0_metadata(exe_file: str, metadata: dict, parsed_obj: lief.MachO.Bin
     metadata["imagebase"] = parsed_obj.imagebase
     metadata["is_pie"] = parsed_obj.is_pie
     metadata["has_nx"] = parsed_obj.has_nx
+    metadata["wx_segments"] = parse_mach0_wx_segments(parsed_obj)
     metadata["exe_type"] = "MachO"
     metadata = add_mach0_versions(exe_file, metadata, parsed_obj)
     if parsed_obj.has_encryption_info and (encryption_info := parsed_obj.encryption_info):

--- a/blint/lib/checks.py
+++ b/blint/lib/checks.py
@@ -9,6 +9,20 @@ def check_nx(f: str, metadata: dict[str, Any], rule_obj: dict[str, Any]) -> bool
     return metadata.get("has_nx") is not False
 
 
+def check_wx_segments(f: str, metadata: dict[str, Any], rule_obj: dict[str, Any]) -> bool | str:  # noqa
+    # A mapping that is writable and executable at the same time turns any
+    # memory-write primitive into direct code execution, so the offending
+    # segments are reported by name.
+    names = [
+        entry.get("name")
+        for entry in metadata.get("wx_segments") or []
+        if isinstance(entry, dict) and entry.get("name")
+    ]
+    if not names:
+        return True
+    return ", ".join(names[:5])
+
+
 def check_pie(f: str, metadata: dict[str, Any], rule_obj: dict[str, Any]) -> bool:  # noqa
     return metadata.get("is_pie") is not False
 

--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -510,6 +510,18 @@ Reports declared dependencies that are never used and used libraries that are ne
 
 Over-linking is largely a property of the distribution rather than the project: builds that pass `--as-needed` are almost free of it, while those that do not accumulate it as link lines are inherited between libraries.
 
+### `wx_segments`
+
+Present for every ELF, PE and Mach-O image. Lists the loadable segments or sections the loader maps both writable and executable, each with its `name`, normalized `permissions` (for example `rwx`) and `virtual_address`. An empty list means the image maintains Write XOR Execute: no code mapping is writable and no data mapping is executable.
+
+What counts as a mapping follows what each platform loader actually enforces:
+
+- **ELF:** `PT_LOAD` program headers carrying both `PF_W` and `PF_X`, named `PT_LOAD[<index>]` by program-header position. An executable `PT_GNU_STACK` is deliberately not listed here; it is a stack-executability defect and is reported by the NX signal (`has_nx`) instead.
+- **PE:** Sections whose characteristics include both `MEM_WRITE` and `MEM_EXECUTE`.
+- **Mach-O:** Segments whose `init_protection` includes both write and execute. `max_protection` is ignored: it describes what a segment may later be remapped to, not what it is mapped with, so a permissive maximum alone does not mean writable code ever existed.
+
+The `CHECK_WX_SEGMENTS` security check turns each entry into a finding naming the segment.
+
 ### `security_properties`
 
 This object provides a quick, at-a-glance summary of the most important security mitigations compiled into the binary.
@@ -517,6 +529,7 @@ This object provides a quick, at-a-glance summary of the most important security
 | Property                 | Description                                                                                                             | Security Implication                                                                                       |
 | :----------------------- | :---------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- |
 | `nx`                     | **Non-eXecutable.** True if data regions (stack/heap) are not executable.                                               | Mitigates code injection attacks.                                                                          |
+| `w_xor_x`                | **Write XOR Execute.** True when no loadable segment is mapped both writable and executable.                            | Keeps code pages unmodifiable at runtime; violations are listed in [`wx_segments`](#wx_segments).          |
 | `pie` / `aslr`           | **Address Space Layout Randomization.**                                                                                 | Makes memory corruption exploits harder by randomizing locations.                                          |
 | `canary`                 | **Stack Cookie.** Confirmed via Load Config or symbols.                                                                 | Mitigates stack-based buffer overflows.                                                                    |
 | `control_flow_guard`     | **CFG (Forward-Edge).** Validates indirect call targets.                                                                | Mitigates function pointer corruption (e.g., vtable hijacking).                                            |

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1151,3 +1151,85 @@ def test_run_wasm_findings_empty_inputs():
     assert run_wasm_findings("clean.wasm", clean_metadata) == []
     assert run_wasm_findings("clean.wasm", {}) == []
     assert run_wasm_findings("clean.wasm", {"wasm_analysis": {}}) == []
+
+
+def test_check_wx_segments_reports_offending_segment_names():
+    metadata = {
+        "exe_type": "genericbinary",
+        "name": "wx.elf",
+        "wx_segments": [
+            {"name": "PT_LOAD[1]", "permissions": "rwx", "virtual_address": "0x401000"},
+            {"name": "PT_LOAD[2]", "permissions": "rwx", "virtual_address": "0x402000"},
+        ],
+    }
+
+    results = [
+        result for result in run_checks("wx.elf", metadata) if result["id"] == "CHECK_WX_SEGMENTS"
+    ]
+
+    assert len(results) == 1
+    assert results[0]["severity"] == "critical"
+    assert "PT_LOAD[1]" in results[0]["title"]
+    assert "PT_LOAD[2]" in results[0]["title"]
+
+
+def test_check_wx_segments_reports_pe_sections_by_name():
+    metadata = {
+        "exe_type": "PE64",
+        "name": "wx.exe",
+        "wx_segments": [
+            {"name": ".rwx", "permissions": "rwx", "virtual_address": "0x2000"},
+        ],
+    }
+
+    results = [
+        result for result in run_checks("wx.exe", metadata) if result["id"] == "CHECK_WX_SEGMENTS"
+    ]
+
+    assert len(results) == 1
+    assert ".rwx" in results[0]["title"]
+
+
+def test_check_wx_segments_ignores_malformed_or_unnamed_entries():
+    metadata = {
+        "exe_type": "MachO",
+        "name": "wx.dylib",
+        "wx_segments": ["__DATA", {"permissions": "rwx"}, {"name": ""}],
+    }
+
+    results = [
+        result
+        for result in run_checks("wx.dylib", metadata)
+        if result["id"] == "CHECK_WX_SEGMENTS"
+    ]
+
+    assert results == []
+
+
+def test_check_wx_segments_passes_without_offending_segments():
+    clean_metadata = {
+        "exe_type": "genericbinary",
+        "name": "ok.elf",
+        "wx_segments": [],
+    }
+    missing_key_metadata = {
+        "exe_type": "PE32",
+        "name": "ok.exe",
+    }
+    other_exe_type_metadata = {
+        "exe_type": "wasmbinary",
+        "name": "module.wasm",
+        "wx_segments": [
+            {"name": "PT_LOAD[1]", "permissions": "rwx", "virtual_address": "0x401000"},
+        ],
+    }
+
+    assert not [r for r in run_checks("ok.elf", clean_metadata) if r["id"] == "CHECK_WX_SEGMENTS"]
+    assert not [
+        r for r in run_checks("ok.exe", missing_key_metadata) if r["id"] == "CHECK_WX_SEGMENTS"
+    ]
+    assert not [
+        r
+        for r in run_checks("module.wasm", other_exe_type_metadata)
+        if r["id"] == "CHECK_WX_SEGMENTS"
+    ]

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -1,4 +1,5 @@
 import os
+import struct
 import sys
 from pathlib import Path
 
@@ -297,6 +298,163 @@ def test_parse_wasm_debug_info_present(tmp_path):
 def test_parse_wasm_debug_info_absent():
     wasm_file = TEST_DATA_DIR / "gc_ops.wasm"
     assert parse(str(wasm_file))["wasm_debug_info_present"] is False
+
+
+def _wx_elf_binary(data_segment_flags: int) -> bytes:
+    """A minimal x86_64 ELF image with a parameterized second PT_LOAD."""
+    ehdrsize, phentsize = 64, 56
+
+    def phdr(p_type, flags, offset, vaddr, memsz):
+        return struct.pack("<IIQQQQQQ", p_type, flags, offset, vaddr, vaddr, memsz, memsz, 0x1000)
+
+    phdrs = [
+        phdr(1, 0x5, 0, 0x400000, 0x1000),  # PT_LOAD R+X
+        phdr(1, data_segment_flags, 0x1000, 0x401000, 0x200),
+        phdr(0x6474E551, 0x6, 0, 0, 0),  # PT_GNU_STACK R+W
+    ]
+    ehdr = struct.pack(
+        "<16sHHIQQQIHHHHHH",
+        b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8,
+        2,  # ET_EXEC
+        62,  # EM_X86_64
+        1,
+        0x400000,
+        ehdrsize,
+        0,
+        0,
+        ehdrsize,
+        phentsize,
+        len(phdrs),
+        64,
+        0,
+        0,
+    )
+    return b"".join([ehdr] + phdrs).ljust(0x1200, b"\x00")
+
+
+def _wx_macho_binary(data_protection: int, data_max_protection: int | None = None) -> bytes:
+    """A minimal x86_64 mach-o image with a parameterized __DATA segment."""
+    if data_max_protection is None:
+        data_max_protection = data_protection
+
+    def segment(name, vmaddr, maxprot, initprot):
+        body = struct.pack(
+            "<16sQQQQiiII",
+            name.encode().ljust(16, b"\x00"),
+            vmaddr,
+            0x1000,
+            vmaddr - 0x100000000,
+            0x1000,
+            maxprot,
+            initprot,
+            0,
+            0,
+        )
+        return struct.pack("<II", 0x19, len(body) + 8) + body
+
+    segments = [
+        segment("__TEXT", 0x100000000, 5, 5),
+        segment("__DATA", 0x100001000, data_max_protection, data_protection),
+    ]
+    header = struct.pack(
+        "<IiiIIIII",
+        0xFEEDFACF,
+        0x01000007,
+        3,
+        2,
+        len(segments),
+        sum(len(s) for s in segments),
+        0,
+        0,
+    )
+    return b"".join([header] + segments).ljust(0x2000, b"\x00")
+
+
+def _wx_pe_binary() -> bytes:
+    """A minimal PE32+ image whose second section is mapped W+X."""
+    dos = bytearray(0x80)
+    dos[0:2] = b"MZ"
+    struct.pack_into("<I", dos, 0x3C, 0x80)
+    coff = struct.pack("<HHIIIHH", 0x8664, 2, 0, 0, 0, 0xF0, 0x0022)
+    optional = bytearray(0xF0)
+    struct.pack_into("<H", optional, 0, 0x20B)  # PE32+ magic
+    struct.pack_into("<I", optional, 32, 4)
+    struct.pack_into("<III", optional, 36, 0x200000, 0x100000, 0x200000)
+    struct.pack_into("<H", optional, 68, 3)  # subsystem: console
+    struct.pack_into("<I", optional, 92, 16)  # numberOfRvaAndSizes
+
+    def section(name, va, raw_ptr, characteristics):
+        return struct.pack(
+            "<8sIIIIIIHHI", name.encode(), 0x200, va, 0x200, raw_ptr, 0, 0, 0, 0, characteristics
+        )
+
+    sections = [
+        section(".text", 0x1000, 0x200, 0x60000020),  # R+X
+        section(".rwx", 0x2000, 0x400, 0xE0000040),  # R+W+X
+    ]
+    return b"".join([bytes(dos), b"PE\x00\x00", coff, bytes(optional)] + sections).ljust(
+        0x600, b"\x00"
+    )
+
+
+def test_parse_collects_wx_elf_load_segments(tmp_path):
+    exe_file = tmp_path / "wx.elf"
+    exe_file.write_bytes(_wx_elf_binary(0x7))  # R+W+X
+    metadata = parse(str(exe_file))
+
+    assert metadata["wx_segments"] == [
+        {"name": "PT_LOAD[1]", "permissions": "rwx", "virtual_address": "0x401000"}
+    ]
+    assert metadata["security_properties"]["w_xor_x"] is False
+
+
+def test_parse_reports_no_wx_elf_load_segments_without_them(tmp_path):
+    exe_file = tmp_path / "ok.elf"
+    exe_file.write_bytes(_wx_elf_binary(0x6))  # R+W
+    metadata = parse(str(exe_file))
+
+    assert metadata["wx_segments"] == []
+    assert metadata["security_properties"]["w_xor_x"] is True
+
+
+def test_parse_collects_wx_macho_segments_from_initial_protection(tmp_path):
+    exe_file = tmp_path / "wx.macho"
+    exe_file.write_bytes(_wx_macho_binary(0x7))  # initprot R+W+X
+    metadata = parse(str(exe_file))
+
+    assert metadata["wx_segments"] == [
+        {"name": "__DATA", "permissions": "rwx", "virtual_address": "0x100001000"}
+    ]
+
+
+def test_parse_ignores_permissive_macho_max_protection(tmp_path):
+    # max_protection only describes what the segment may be remapped to, so a
+    # writable-executable maximum over a read-write mapping is not a finding.
+    exe_file = tmp_path / "maxprot.macho"
+    exe_file.write_bytes(_wx_macho_binary(0x3, 0x7))  # initprot R+W, maxprot R+W+X
+    metadata = parse(str(exe_file))
+
+    assert metadata["wx_segments"] == []
+
+
+def test_parse_reports_no_wx_macho_segments_for_standard_images(tmp_path):
+    exe_file = tmp_path / "ok.macho"
+    exe_file.write_bytes(_wx_macho_binary(0x3))  # initprot R+W
+    metadata = parse(str(exe_file))
+
+    assert metadata["wx_segments"] == []
+    assert metadata["security_properties"]["w_xor_x"] is True
+
+
+def test_parse_collects_wx_pe_sections(tmp_path):
+    exe_file = tmp_path / "wx.exe"
+    exe_file.write_bytes(_wx_pe_binary())
+    metadata = parse(str(exe_file))
+
+    assert metadata["wx_segments"] == [
+        {"name": ".rwx", "permissions": "rwx", "virtual_address": "0x2000"}
+    ]
+    assert metadata["security_properties"]["w_xor_x"] is False
 
 
 def test_parse_wasm_flags_omit_strings_and_call_graph():


### PR DESCRIPTION
https://purplesyringa.moe/blog/guest/the-nx-bit-is-not-just-about-security/ 

On ARM, non-executable permission is the only mechanism that prevents speculative instruction fetches to a region. The root cause was a mispredicted indirect branch (blr) speculatively fetching from an executable mapping over MMIO, hanging the SoC; the failure only existed because the hypervisor mapped everything executable, i.e. it violated W^X out of laziness ("it's only a security feature"). NX is a functional requirement, not just hardening.

Auditing blint against this: CHECK_NX covers only stack executability (LIEF's has_nx, GNU_STACK/NX_COMPAT based). There was no check for W+X mappings, the broadest form of "executable memory that shouldn't be", anywhere in the rules, checks, or metadata.

### What was implemented

- CHECK_WX_SEGMENTS (new critical rule in rules.yml, right after CHECK_NX): fires when a loadable mapping is both writable and executable, naming the offending segments in the title (e.g. Writable and Executable Memory Segment (PT_LOAD[1])). The description covers the W^X invariant, remediation (mprotect/VirtualProtect flipping, JIT write-protection, readelf -l / dumpbin /headers), and the ARM speculative-fetch correctness angle — grounded in ARM's documented behavior, with no reference to the post.
- wx_segments metadata key (additive; binary.py): per-format extraction of exactly what the loader enforces — ELF PT_LOAD with PF_W|PF_X (executable GNU_STACK deliberately excluded so one defect = one finding, since CHECK_NX owns it), PE sections with MEM_WRITE|MEM_EXECUTE, Mach-O segments whose init_protection allows both (max_protection ignored — it's routinely more permissive and never proven actually mapped; verified against real macOS binaries where init always equals max).
- w_xor_x boolean in the security_properties summary, plus a wx_segments section and table row in docs/METADATA.md.